### PR TITLE
[DOCS] add AUR installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ yay -S sone-bin
 paru -S sone-bin
 ```
 
-### Manual Install
+#### Manual Install
 
 ```bash
 sudo pacman -S --needed \


### PR DESCRIPTION
Add `sone-bin` AUR package to installation docs

`sone-bin` is now available on the AUR as a pre-built binary package for Arch Linux users.

Changes:
- Added AUR badge alongside existing Arch Linux PKGBUILD badge
- Added AUR installation section with `yay`/`paru` examples

AUR package: https://aur.archlinux.org/packages/sone-bin