### PR TITLE
Add SOCKS5/HTTP proxy support

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4293,6 +4293,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-socks",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -5519,6 +5520,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror 1.0.69",
  "tokio",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,7 +29,7 @@ gstreamer-app = "0.23"
 crossbeam-channel = "0.5"
 walkdir = "2"
 id3 = "1"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", features = ["json", "socks"] }
 tokio = { version = "1", features = ["full"] }
 base64 = "0.21"
 dirs = "5"

--- a/src-tauri/src/commands/utility.rs
+++ b/src-tauri/src/commands/utility.rs
@@ -32,7 +32,8 @@ pub async fn get_image_bytes(
             Ok(bytes)
         }
         CacheResult::Miss => {
-            let res = reqwest::get(&url).await?;
+            let client = state.http_client.lock().unwrap().clone();
+            let res = client.get(&url).send().await?;
             let bytes = res.bytes().await?.to_vec();
 
             state
@@ -225,4 +226,39 @@ pub fn list_audio_devices(state: State<'_, AppState>) -> Result<Vec<AudioDevice>
     let devices = crate::audio::list_alsa_devices().map_err(SoneError::Audio)?;
     *state.cached_audio_devices.lock().unwrap() = Some(devices.clone());
     Ok(devices)
+}
+
+#[tauri::command]
+pub fn get_proxy_url(state: State<'_, AppState>) -> Option<String> {
+    state.load_settings().and_then(|s| s.proxy_url)
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn set_proxy_url(
+    state: State<'_, AppState>,
+    proxy_url: Option<String>,
+) -> Result<(), SoneError> {
+    let url_ref = proxy_url.as_deref().filter(|u| !u.is_empty());
+
+    // Validate the proxy URL before saving (skip validation for None/empty)
+    if let Some(url) = url_ref {
+        reqwest::Proxy::all(url).map_err(|e| {
+            SoneError::Parse(format!("Invalid proxy URL: {e}"))
+        })?;
+    }
+
+    // Rebuild HTTP clients with the new proxy setting
+    *state.http_client.lock().unwrap() = crate::tidal_api::build_http_client(url_ref);
+    let mut client = state.tidal_client.lock().await;
+    client.set_proxy(url_ref);
+    drop(client);
+
+    let mut settings = state.load_settings().unwrap_or_default();
+    settings.proxy_url = proxy_url.filter(|u| !u.is_empty());
+    state.save_settings(&settings)?;
+    log::info!(
+        "[set_proxy_url]: proxy {}",
+        if settings.proxy_url.is_some() { "enabled" } else { "disabled" }
+    );
+    Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -77,6 +77,8 @@ pub struct Settings {
     pub bit_perfect: bool,
     #[serde(default)]
     pub scrobble: ScrobbleSettings,
+    #[serde(default)]
+    pub proxy_url: Option<String>,
 }
 
 impl Default for Settings {
@@ -94,6 +96,7 @@ impl Default for Settings {
             exclusive_device: None,
             bit_perfect: false,
             scrobble: Default::default(),
+            proxy_url: None,
         }
     }
 }
@@ -112,6 +115,8 @@ pub struct AppState {
     pub bit_perfect: AtomicBool,
     pub exclusive_device: std::sync::Mutex<Option<String>>,
     pub cached_audio_devices: std::sync::Mutex<Option<Vec<AudioDevice>>>,
+    /// General-purpose HTTP client (proxy-aware). Used for image downloads etc.
+    pub http_client: std::sync::Mutex<reqwest::Client>,
     /// Current track's selected replay gain (dB) stored as f64 bits. NAN = no data.
     /// Album or track gain depending on playback context.
     pub last_replay_gain: AtomicU64,
@@ -187,13 +192,18 @@ impl AppState {
         let exclusive_mode = saved.as_ref().map(|s| s.exclusive_mode).unwrap_or(false);
         let bit_perfect = saved.as_ref().map(|s| s.bit_perfect).unwrap_or(false);
         let exclusive_device = saved.as_ref().and_then(|s| s.exclusive_device.clone());
+        let proxy_url = saved.as_ref().and_then(|s| s.proxy_url.clone());
 
         let scrobble_manager =
             scrobble::ScrobbleManager::new(app_handle.clone(), crypto.clone(), &config_dir);
 
+        let http_client = tidal_api::build_http_client(proxy_url.as_deref());
+        let mut tidal_client = TidalClient::new();
+        tidal_client.set_proxy(proxy_url.as_deref());
+
         Self {
             audio_player: AudioPlayer::new(app_handle.clone()),
-            tidal_client: Mutex::new(TidalClient::new()),
+            tidal_client: Mutex::new(tidal_client),
             settings_path,
             cache_dir,
             disk_cache,
@@ -205,6 +215,7 @@ impl AppState {
             bit_perfect: AtomicBool::new(bit_perfect),
             exclusive_device: std::sync::Mutex::new(exclusive_device),
             cached_audio_devices: std::sync::Mutex::new(None),
+            http_client: std::sync::Mutex::new(http_client),
             last_replay_gain: AtomicU64::new(f64::NAN.to_bits()),
             last_peak_amplitude: AtomicU64::new(f64::NAN.to_bits()),
             #[cfg(target_os = "linux")]
@@ -675,6 +686,8 @@ pub fn run() {
             commands::utility::get_exclusive_device,
             commands::utility::set_exclusive_device,
             commands::utility::list_audio_devices,
+            commands::utility::get_proxy_url,
+            commands::utility::set_proxy_url,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/tidal_api.rs
+++ b/src-tauri/src/tidal_api.rs
@@ -4,6 +4,33 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::time::Duration;
 
+/// Build a reqwest `Client` with an optional proxy URL.
+/// `proxy_url` should be in one of the forms accepted by reqwest:
+/// `socks5://host:port`, `socks5h://host:port`, or `http://host:port`.
+pub fn build_http_client(proxy_url: Option<&str>) -> Client {
+    let mut builder = Client::builder().timeout(Duration::from_secs(30));
+    if let Some(url) = proxy_url.filter(|u| !u.is_empty()) {
+        match reqwest::Proxy::all(url) {
+            Ok(proxy) => {
+                builder = builder.proxy(proxy);
+                log::info!("[build_http_client]: proxy configured");
+            }
+            Err(e) => {
+                log::warn!("[build_http_client]: invalid proxy URL: {e}");
+            }
+        }
+    }
+    match builder.build() {
+        Ok(client) => client,
+        Err(e) => {
+            log::error!(
+                "[build_http_client]: failed to build HTTP client with configured settings: {e}; falling back to default client without timeout/proxy"
+            );
+            Client::new()
+        }
+    }
+}
+
 const TIDAL_AUTH_URL: &str = "https://auth.tidal.com/v1/oauth2";
 const TIDAL_API_URL: &str = "https://api.tidal.com/v1";
 const TIDAL_API_V2_URL: &str = "https://api.tidal.com/v2";
@@ -815,15 +842,18 @@ pub struct TidalClient {
 impl TidalClient {
     pub fn new() -> Self {
         Self {
-            client: Client::builder()
-                .timeout(Duration::from_secs(30))
-                .build()
-                .unwrap(),
+            client: build_http_client(None),
             tokens: None,
             client_id: String::new(),
             client_secret: String::new(),
             country_code: "US".to_string(),
         }
+    }
+
+    /// Rebuild the internal HTTP client to route traffic through `proxy_url`.
+    /// Pass `None` or an empty string to clear the proxy.
+    pub fn set_proxy(&mut self, proxy_url: Option<&str>) {
+        self.client = build_http_client(proxy_url);
     }
 
     pub fn set_credentials(&mut self, client_id: &str, client_secret: &str) {

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -13,8 +13,9 @@ import {
   Shield,
   ChevronDown,
   Radio,
+  Globe,
 } from "lucide-react";
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { useAtom } from "jotai";
 import { useAuth } from "../hooks/useAuth";
@@ -28,6 +29,7 @@ import {
 import { useToast } from "../contexts/ToastContext";
 import ThemeEditor from "./ThemeEditor";
 import ScrobbleModal from "./ScrobbleModal";
+import { formatSoneError } from "../lib/errorUtils";
 
 const SHORTCUTS = [
   { keys: "Space", desc: "Play / Pause" },
@@ -65,6 +67,22 @@ export default function UserMenu() {
   const [autoplay, setAutoplay] = useAtom(autoplayAtom);
   const { showToast } = useToast();
   const menuRef = useRef<HTMLDivElement>(null);
+  const [proxyUrl, setProxyUrl] = useState("");
+  const [proxyEditing, setProxyEditing] = useState(false);
+  const [proxyDraft, setProxyDraft] = useState("");
+
+  const saveProxy = useCallback(() => {
+    const url = proxyDraft.trim() || null;
+    invoke("set_proxy_url", { proxyUrl: url })
+      .then(() => {
+        setProxyUrl(proxyDraft.trim());
+        setProxyEditing(false);
+        showToast(url ? "Proxy saved and applied" : "Proxy cleared");
+      })
+      .catch((err: unknown) => {
+        showToast(`Invalid proxy URL: ${formatSoneError(err)}`);
+      });
+  }, [proxyDraft, showToast]);
 
   // Load preferences (exclusive/bitPerfect/device are from Jotai atoms, hydrated by AppInitializer)
   useEffect(() => {
@@ -76,6 +94,9 @@ export default function UserMenu() {
       .catch(() => {});
     invoke<boolean>("get_decorations")
       .then(setDecorations)
+      .catch(() => {});
+    invoke<string | null>("get_proxy_url")
+      .then((url) => setProxyUrl(url ?? ""))
       .catch(() => {});
   }, []);
 
@@ -381,6 +402,60 @@ export default function UserMenu() {
               />
             </div>
           </button>
+
+          {/* SOCKS5 / HTTP proxy */}
+          {proxyEditing ? (
+            <div className="px-4 py-2">
+              <div className="flex items-center gap-2 mb-1">
+                <Globe size={16} className="text-th-text-secondary shrink-0" />
+                <span className="text-[13px] text-th-text-secondary">Proxy URL</span>
+              </div>
+              <div className="flex gap-2 ml-6">
+                <input
+                  type="text"
+                  value={proxyDraft}
+                  onChange={(e) => setProxyDraft(e.target.value)}
+                  placeholder="socks5://127.0.0.1:1080"
+                  aria-label="Proxy URL"
+                  className="flex-1 px-2 py-1 text-[12px] bg-th-inset border border-th-border-subtle rounded-md text-white placeholder-th-text-muted focus:outline-none focus:border-th-accent/60"
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      saveProxy();
+                    } else if (e.key === "Escape") {
+                      setProxyEditing(false);
+                    }
+                  }}
+                  autoFocus
+                />
+                <button
+                  onClick={saveProxy}
+                  className="px-2 py-1 text-[12px] bg-th-accent/20 hover:bg-th-accent/30 text-th-accent rounded-md transition-colors"
+                >
+                  Save
+                </button>
+                <button
+                  onClick={() => setProxyEditing(false)}
+                  className="px-2 py-1 text-[12px] hover:bg-th-border-subtle text-th-text-muted rounded-md transition-colors"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              onClick={() => {
+                setProxyDraft(proxyUrl);
+                setProxyEditing(true);
+              }}
+              className="w-full flex items-center gap-3 px-4 py-2.5 text-[13px] text-th-text-secondary hover:text-white hover:bg-th-border-subtle transition-colors"
+            >
+              <Globe size={16} />
+              <span className="flex-1 text-left">Proxy</span>
+              <span className="text-[11px] text-th-text-muted truncate max-w-[120px]">
+                {proxyUrl || "none"}
+              </span>
+            </button>
+          )}
 
           {/* ── Utilities ── */}
           <div className="border-t border-th-border-subtle my-1" />


### PR DESCRIPTION
This pull request adds full support for configuring an HTTP or SOCKS proxy for network requests throughout the application, including both backend and frontend integration. 
Users can now set or clear a proxy URL in the UI, which is validated, persisted in settings, and applied to all relevant HTTP clients. The changes touch Rust backend logic, settings management, HTTP client construction, and frontend user interface.

**Proxy support and configuration (major theme):**

* Added `proxy_url` field to `Settings` struct, persisted via serialization and defaulted to `None`. [[1]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cR80-R81) [[2]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cR99)
* Introduced `http_client` field in `AppState`, initialized with proxy settings on startup, and rebuilt whenever proxy changes. [[1]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cR118-R119) [[2]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cR195-R206) [[3]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cR218)
* Created `build_http_client` function in `tidal_api.rs` to construct a `reqwest::Client` with optional proxy, including error handling and logging.
* Updated `TidalClient` to use proxy-aware client and added `set_proxy` method to allow dynamic proxy changes.

**Backend commands and request handling:**

* Added `get_proxy_url` and `set_proxy_url` Tauri commands for frontend integration; `set_proxy_url` validates and applies proxy, updating HTTP clients and persisting to settings. [[1]](diffhunk://#diff-913b719008942c073f4e2fca5ece8ea753caa96aca7c488ec2e810543b5aadc2R230-R264) [[2]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cR689-R690)
* Modified image download logic to use the shared proxy-aware HTTP client rather than direct `reqwest::get`.
* Enabled `socks` feature in `reqwest` dependency to support SOCKS proxies.

**Frontend integration and UI improvements:**

* Added proxy configuration section to `UserMenu` component, allowing users to view, edit, and save proxy URL with validation and feedback.
* On mount, loads current proxy URL from backend and updates UI state.
* Utilizes new Tauri commands (`get_proxy_url`, `set_proxy_url`) and provides error feedback using `formatSoneError`. [[1]](diffhunk://#diff-07bfb1512b3036910c09f113e6c8bbee2b5adb34957646cf7df42c579a6010a6R70-R85) [[2]](diffhunk://#diff-07bfb1512b3036910c09f113e6c8bbee2b5adb34957646cf7df42c579a6010a6R32)
* Added `Globe` icon for proxy UI.