### PR TITLE
feat: add customizable Discord status text

### DIFF
--- a/src-tauri/src/commands/utility.rs
+++ b/src-tauri/src/commands/utility.rs
@@ -252,6 +252,26 @@ pub fn set_discord_rpc(state: State<'_, AppState>, enabled: bool) -> Result<(), 
 }
 
 #[tauri::command]
+pub fn get_discord_status_text(state: State<'_, AppState>) -> String {
+    state
+        .load_settings()
+        .map(|s| s.discord_status_text)
+        .unwrap_or_default()
+}
+
+#[tauri::command]
+pub fn set_discord_status_text(state: State<'_, AppState>, text: String) -> Result<(), SoneError> {
+    state
+        .discord
+        .send(crate::discord::DiscordCommand::SetStatusText { text: text.clone() });
+
+    let mut settings = state.load_settings().unwrap_or_default();
+    settings.discord_status_text = text;
+    state.save_settings(&settings)?;
+    Ok(())
+}
+
+#[tauri::command]
 pub fn get_proxy_settings(state: State<'_, AppState>) -> crate::ProxySettings {
     state
         .load_settings()

--- a/src-tauri/src/discord.rs
+++ b/src-tauri/src/discord.rs
@@ -22,12 +22,29 @@ pub enum DiscordCommand {
     Seeked {
         position_secs: f64,
     },
+    SetStatusText {
+        text: String,
+    },
     Connect,
     Disconnect,
 }
 
 pub struct DiscordHandle {
     tx: mpsc::Sender<DiscordCommand>,
+}
+
+#[derive(Default)]
+struct CurrentActivity {
+    title: String,
+    artist: String,
+    album: String,
+    art_url: String,
+    duration_secs: f64,
+    url: String,
+    quality_text: String,
+    status_text: String,
+    is_playing: bool,
+    play_start_epoch: i64,
 }
 
 impl DiscordHandle {
@@ -39,60 +56,40 @@ impl DiscordHandle {
 
             let mut connected = false;
             let mut want_connected = false;
-            let mut current_title = String::new();
-            let mut current_artist = String::new();
-            let mut current_album = String::new();
-            let mut current_art_url = String::new();
-            let mut current_duration_secs: f64 = 0.0;
-            let mut current_url = String::new();
-            let mut current_quality_text = String::new();
-            let mut is_playing = false;
-            let mut play_start_epoch: i64 = 0;
+            let mut current = CurrentActivity::default();
 
             // Try to establish or re-establish the IPC connection.
             // Always creates a fresh client to avoid stale socket issues.
-            let try_connect =
-                |client: &mut DiscordIpcClient, connected: &mut bool| -> bool {
-                    if *connected {
-                        return true;
+            let try_connect = |client: &mut DiscordIpcClient, connected: &mut bool| -> bool {
+                if *connected {
+                    return true;
+                }
+                *client = DiscordIpcClient::new(APPLICATION_ID);
+                match client.connect() {
+                    Ok(()) => {
+                        *connected = true;
+                        log::info!("Discord Rich Presence connected");
+                        true
                     }
-                    *client = DiscordIpcClient::new(APPLICATION_ID);
-                    match client.connect() {
-                        Ok(()) => {
-                            *connected = true;
-                            log::info!("Discord Rich Presence connected");
-                            true
-                        }
-                        Err(e) => {
-                            log::warn!("Failed to connect Discord IPC: {e}");
-                            false
-                        }
+                    Err(e) => {
+                        log::warn!("Failed to connect Discord IPC: {e}");
+                        false
                     }
-                };
+                }
+            };
 
             for cmd in rx {
                 match cmd {
                     DiscordCommand::Connect => {
                         want_connected = true;
                         try_connect(&mut client, &mut connected);
-                        if connected && is_playing && !current_title.is_empty() {
-                            if set_activity(
-                                &mut client,
-                                &current_title,
-                                &current_artist,
-                                &current_album,
-                                &current_art_url,
-                                current_duration_secs,
-                                is_playing,
-                                play_start_epoch,
-                                &current_url,
-                                &current_quality_text,
-                            )
-                            .is_err()
-                            {
-                                client.close().ok();
-                                connected = false;
-                            }
+                        if connected
+                            && current.is_playing
+                            && !current.title.is_empty()
+                            && publish_activity(&mut client, &current).is_err()
+                        {
+                            client.close().ok();
+                            connected = false;
                         }
                     }
                     DiscordCommand::Disconnect => {
@@ -113,46 +110,34 @@ impl DiscordHandle {
                         url,
                         quality_text,
                     } => {
-                        current_title = title;
-                        current_artist = artist;
-                        current_album = album;
-                        current_art_url = art_url;
-                        current_duration_secs = duration_secs;
-                        current_url = url;
-                        current_quality_text = quality_text;
+                        current.title = title;
+                        current.artist = artist;
+                        current.album = album;
+                        current.art_url = art_url;
+                        current.duration_secs = duration_secs;
+                        current.url = url;
+                        current.quality_text = quality_text;
 
-                        if is_playing {
-                            play_start_epoch = now_epoch_secs();
+                        if current.is_playing {
+                            current.play_start_epoch = now_epoch_secs();
                         }
 
                         if want_connected {
                             try_connect(&mut client, &mut connected);
-                            if connected {
-                                if set_activity(
-                                    &mut client,
-                                    &current_title,
-                                    &current_artist,
-                                    &current_album,
-                                    &current_art_url,
-                                    current_duration_secs,
-                                    is_playing,
-                                    play_start_epoch,
-                                    &current_url,
-                                    &current_quality_text,
-                                )
-                                .is_err()
-                                {
-                                    client.close().ok();
-                                    connected = false;
-                                }
+                            if connected && publish_activity(&mut client, &current).is_err() {
+                                client.close().ok();
+                                connected = false;
                             }
                         }
                     }
-                    DiscordCommand::SetPlaying { is_playing: playing, position_secs } => {
-                        is_playing = playing;
+                    DiscordCommand::SetPlaying {
+                        is_playing: playing,
+                        position_secs,
+                    } => {
+                        current.is_playing = playing;
 
                         if playing {
-                            play_start_epoch = now_epoch_secs() - position_secs as i64;
+                            current.play_start_epoch = now_epoch_secs() - position_secs as i64;
                         }
 
                         if want_connected {
@@ -161,19 +146,7 @@ impl DiscordHandle {
                                 let failed = if !playing {
                                     client.clear_activity().is_err()
                                 } else {
-                                    set_activity(
-                                        &mut client,
-                                        &current_title,
-                                        &current_artist,
-                                        &current_album,
-                                        &current_art_url,
-                                        current_duration_secs,
-                                        is_playing,
-                                        play_start_epoch,
-                                        &current_url,
-                                        &current_quality_text,
-                                    )
-                                    .is_err()
+                                    publish_activity(&mut client, &current).is_err()
                                 };
                                 if failed {
                                     client.close().ok();
@@ -182,30 +155,30 @@ impl DiscordHandle {
                             }
                         }
                     }
+                    DiscordCommand::SetStatusText { text } => {
+                        current.status_text = text;
+                        if want_connected
+                            && connected
+                            && current.is_playing
+                            && !current.title.is_empty()
+                            && publish_activity(&mut client, &current).is_err()
+                        {
+                            client.close().ok();
+                            connected = false;
+                        }
+                    }
                     DiscordCommand::Stop => {
-                        current_title.clear();
+                        current.title.clear();
                     }
                     DiscordCommand::Seeked { position_secs } => {
-                        if is_playing {
-                            play_start_epoch = now_epoch_secs() - position_secs as i64;
-                            if want_connected && connected {
-                                if set_activity(
-                                    &mut client,
-                                    &current_title,
-                                    &current_artist,
-                                    &current_album,
-                                    &current_art_url,
-                                    current_duration_secs,
-                                    is_playing,
-                                    play_start_epoch,
-                                    &current_url,
-                                    &current_quality_text,
-                                )
-                                .is_err()
-                                {
-                                    client.close().ok();
-                                    connected = false;
-                                }
+                        if current.is_playing {
+                            current.play_start_epoch = now_epoch_secs() - position_secs as i64;
+                            if want_connected
+                                && connected
+                                && publish_activity(&mut client, &current).is_err()
+                            {
+                                client.close().ok();
+                                connected = false;
                             }
                         }
                     }
@@ -234,50 +207,51 @@ fn now_epoch_secs() -> i64 {
         .as_secs() as i64
 }
 
-fn set_activity(
-    client: &mut DiscordIpcClient,
-    title: &str,
-    artist: &str,
-    album: &str,
-    art_url: &str,
-    duration_secs: f64,
-    is_playing: bool,
-    play_start_epoch: i64,
-    url: &str,
-    quality_text: &str,
-) -> Result<(), ()> {
-    let state_text = if artist.is_empty() {
-        album.to_string()
-    } else if album.is_empty() {
-        format!("by {artist}")
+fn publish_activity(client: &mut DiscordIpcClient, current: &CurrentActivity) -> Result<(), ()> {
+    let state_text = if current.artist.is_empty() {
+        current.album.clone()
+    } else if current.album.is_empty() {
+        format!("by {}", current.artist)
     } else {
-        format!("by {artist} on {album}")
+        format!("by {} on {}", current.artist, current.album)
     };
 
     let mut act = activity::Activity::new()
         .activity_type(activity::ActivityType::Listening)
-        .details(title)
+        .details(current.title.clone())
         .state(&state_text);
+
+    if !current.status_text.trim().is_empty() {
+        let custom_name = render_status_text(
+            &current.status_text,
+            &current.title,
+            &current.artist,
+            &current.album,
+        );
+        if !custom_name.trim().is_empty() {
+            act = act.name(custom_name);
+        }
+    }
 
     // Timestamps: show elapsed time while playing
     let timestamps;
-    if is_playing && play_start_epoch > 0 {
-        timestamps = if duration_secs > 0.0 {
+    if current.is_playing && current.play_start_epoch > 0 {
+        timestamps = if current.duration_secs > 0.0 {
             activity::Timestamps::new()
-                .start(play_start_epoch)
-                .end(play_start_epoch + duration_secs as i64)
+                .start(current.play_start_epoch)
+                .end(current.play_start_epoch + current.duration_secs as i64)
         } else {
-            activity::Timestamps::new().start(play_start_epoch)
+            activity::Timestamps::new().start(current.play_start_epoch)
         };
         act = act.timestamps(timestamps);
     }
 
     // Album art + quality hover text
     let assets;
-    if !art_url.is_empty() {
-        let mut a = activity::Assets::new().large_image(art_url);
-        if !quality_text.is_empty() {
-            a = a.large_text(quality_text);
+    if !current.art_url.is_empty() {
+        let mut a = activity::Assets::new().large_image(current.art_url.clone());
+        if !current.quality_text.is_empty() {
+            a = a.large_text(current.quality_text.clone());
         }
         assets = a;
         act = act.assets(assets);
@@ -285,8 +259,11 @@ fn set_activity(
 
     // "Listen on TIDAL" button
     let buttons;
-    if !url.is_empty() {
-        buttons = vec![activity::Button::new("Listen on TIDAL", url)];
+    if !current.url.is_empty() {
+        buttons = vec![activity::Button::new(
+            "Listen on TIDAL",
+            current.url.clone(),
+        )];
         act = act.buttons(buttons);
     }
 
@@ -295,4 +272,11 @@ fn set_activity(
         return Err(());
     }
     Ok(())
+}
+
+fn render_status_text(template: &str, title: &str, artist: &str, album: &str) -> String {
+    template
+        .replace("{track}", title)
+        .replace("{artist}", artist)
+        .replace("{album}", album)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -118,6 +118,8 @@ pub struct Settings {
     pub proxy: ProxySettings,
     #[serde(default = "defaults::yes")]
     pub discord_rpc: bool,
+    #[serde(default)]
+    pub discord_status_text: String,
 }
 
 impl Default for Settings {
@@ -138,6 +140,7 @@ impl Default for Settings {
             scrobble: Default::default(),
             proxy: Default::default(),
             discord_rpc: true,
+            discord_status_text: String::new(),
         }
     }
 }
@@ -271,7 +274,14 @@ impl AppState {
         );
 
         let discord_rpc_enabled = saved.as_ref().map(|s| s.discord_rpc).unwrap_or(true);
+        let discord_status_text = saved
+            .as_ref()
+            .map(|s| s.discord_status_text.clone())
+            .unwrap_or_default();
         let discord_handle = discord::DiscordHandle::new();
+        discord_handle.send(discord::DiscordCommand::SetStatusText {
+            text: discord_status_text,
+        });
         if discord_rpc_enabled {
             discord_handle.send(discord::DiscordCommand::Connect);
         }
@@ -754,6 +764,8 @@ pub fn run() {
             commands::utility::list_audio_devices,
             commands::utility::get_discord_rpc,
             commands::utility::set_discord_rpc,
+            commands::utility::get_discord_status_text,
+            commands::utility::set_discord_status_text,
             commands::utility::get_proxy_settings,
             commands::utility::set_proxy_settings,
             commands::utility::test_proxy_connection,

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -269,7 +269,9 @@ export default function SettingsModal({ open, onClose }: SettingsModalProps) {
               </h3>
 
               {/* Discord Rich Presence */}
-              <div className="flex items-center justify-between py-3">
+            <div className="flex items-center justify-between pt-3"
+                style={{ paddingBottom: discordRpc ? "6px" : "12px" }}  // Adjust padding based on Discord RPC status
+              >
                 <div className="flex items-center gap-3 min-w-0">
                   <MessageSquare
                     size={16}
@@ -296,18 +298,20 @@ export default function SettingsModal({ open, onClose }: SettingsModalProps) {
                   <Toggle on={discordRpc} />
                 </button>
               </div>
-              <div className="pl-7 pb-2 space-y-1.5">
-                <label className="block text-[11px] text-th-text-muted">
-                  Status text
-                </label>
-                <input
-                  type="text"
-                  value={discordStatusText}
-                  onChange={(e) => updateDiscordStatusText(e.target.value)}
-                  placeholder="{track} by {artist} on {album}"
-                  className="w-full px-2.5 py-1.5 rounded-md bg-th-inset border border-th-border-subtle text-[12px] text-th-text-primary placeholder:text-th-text-muted focus:border-th-accent/50 focus:outline-none"
-                />
-              </div>
+              {discordRpc && (
+                <div className="pl-7 pb-2 space-y-1.5">
+                  <label className="block text-[11px] text-th-text-muted">
+                    Status text
+                  </label>
+                  <input
+                    type="text"
+                    value={discordStatusText}
+                    onChange={(e) => updateDiscordStatusText(e.target.value)}
+                    placeholder="{track} by {artist} on {album}"
+                    className="w-full px-2.5 py-1.5 rounded-md bg-th-inset border border-th-border-subtle text-[12px] text-th-text-primary placeholder:text-th-text-disabled focus:border-th-accent/50 focus:outline-none"
+                  />
+                </div>
+              )}
             </div>
 
             {/* ── General ── */}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -78,6 +78,7 @@ export default function SettingsModal({ open, onClose }: SettingsModalProps) {
   const [bitPerfect] = useAtom(bitPerfectAtom);
   const [volumeNormalization, setVolumeNormalization] = useState(false);
   const [discordRpc, setDiscordRpc] = useState(false);
+  const [discordStatusText, setDiscordStatusText] = useState("");
   const [decorations, setDecorations] = useAtom(decorationsAtom);
   const [hideTitleBar, setHideTitleBar] = useAtom(hideTitleBarAtom);
   const [minimizeToTray, setMinimizeToTray] = useState(false);
@@ -89,6 +90,7 @@ export default function SettingsModal({ open, onClose }: SettingsModalProps) {
   const { showToast } = useToast();
   const panelRef = useRef<HTMLDivElement>(null);
   const proxySaveTimer = useRef<number | undefined>(undefined);
+  const discordStatusSaveTimer = useRef<number | undefined>(undefined);
 
   // Load backend-synced preferences when modal opens
   useEffect(() => {
@@ -104,7 +106,17 @@ export default function SettingsModal({ open, onClose }: SettingsModalProps) {
     invoke<boolean>("get_discord_rpc")
       .then(setDiscordRpc)
       .catch(() => {});
+    invoke<string>("get_discord_status_text")
+      .then(setDiscordStatusText)
+      .catch(() => {});
   }, [open]);
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(proxySaveTimer.current);
+      clearTimeout(discordStatusSaveTimer.current);
+    };
+  }, []);
 
   // Close on click outside
   useEffect(() => {
@@ -135,6 +147,14 @@ export default function SettingsModal({ open, onClose }: SettingsModalProps) {
     clearTimeout(proxySaveTimer.current);
     proxySaveTimer.current = window.setTimeout(() => {
       invoke("set_proxy_settings", { settings: next }).catch(() => {});
+    }, 500);
+  };
+
+  const updateDiscordStatusText = (text: string) => {
+    setDiscordStatusText(text);
+    clearTimeout(discordStatusSaveTimer.current);
+    discordStatusSaveTimer.current = window.setTimeout(() => {
+      invoke("set_discord_status_text", { text }).catch(() => {});
     }, 500);
   };
 
@@ -275,6 +295,18 @@ export default function SettingsModal({ open, onClose }: SettingsModalProps) {
                 >
                   <Toggle on={discordRpc} />
                 </button>
+              </div>
+              <div className="pl-7 pb-2 space-y-1.5">
+                <label className="block text-[11px] text-th-text-muted">
+                  Status text
+                </label>
+                <input
+                  type="text"
+                  value={discordStatusText}
+                  onChange={(e) => updateDiscordStatusText(e.target.value)}
+                  placeholder="{track} by {artist} on {album}"
+                  className="w-full px-2.5 py-1.5 rounded-md bg-th-inset border border-th-border-subtle text-[12px] text-th-text-primary placeholder:text-th-text-muted focus:border-th-accent/50 focus:outline-none"
+                />
               </div>
             </div>
 


### PR DESCRIPTION
Added a new feature that allows users to customize the Discord Rich Presence status text. 
I don't know much Rust yet, so I got some help from GPT-5.5. 
Please feel free to request any changes or even rewrite the feature using your own code, as you are much more familiar with the codebase 🙂

Summary
- Add a customizable Discord Rich Presence status text setting that supports {track}, {artist}, and {album} template placeholders
- Expose get_discord_status_text / set_discord_status_text Tauri commands and persist the value in encrypted settings
- Refactor discord.rs: consolidate loose state variables into a CurrentActivity struct and replace the multi-parameter set_activity function with publish_activity, reducing duplication across all command handlers
- Add a text input in the Settings modal (below the Discord RPC toggle) with debounced save, so changes apply in real-time without requiring a restart

Screenshots:
<img width="1027" height="549" alt="image" src="https://github.com/user-attachments/assets/8af4549d-49c5-486a-8b3a-1ffbc5ff170b" />
