### PR TITLE
fix: disable WebKitGTK DMA-BUF renderer on NVIDIA under Wayland

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,14 +4,38 @@
 fn main() {
     #[cfg(target_os = "linux")]
     {
-        // NVIDIA GPUs can't allocate GBM buffers for WebKitGTK's DMA-BUF
-        // renderer on Wayland.
-        // Shared-memory fallback works fine.
-        if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
-            if let Ok(modules) = std::fs::read_to_string("/proc/modules") {
-                if modules.contains("nvidia") {
-                    std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
-                }
+        // WebKitGTK's DMA-BUF renderer fails to allocate GBM buffers on
+        // NVIDIA + Wayland (issue #87, tauri-apps/tauri#10702, WebKit
+        // Bugzilla #261874). Fall back to shared-memory rendering when an
+        // NVIDIA kernel module is loaded under a Wayland session. Pre-set
+        // WEBKIT_DISABLE_DMABUF_RENDERER to override.
+        //
+        // TODO: revisit when WebKitGTK resolves the NVIDIA DMA-BUF bug.
+        let on_wayland = std::env::var("XDG_SESSION_TYPE")
+            .map(|v| v.eq_ignore_ascii_case("wayland"))
+            .unwrap_or(false);
+        let already_overridden =
+            std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_some();
+
+        if on_wayland && !already_overridden {
+            let nvidia_loaded = std::fs::read_to_string("/proc/modules")
+                .map(|modules| {
+                    modules.lines().any(|line| {
+                        line.split_whitespace()
+                            .next()
+                            .map(|name| name == "nvidia" || name.starts_with("nvidia_"))
+                            .unwrap_or(false)
+                    })
+                })
+                .unwrap_or(false);
+
+            if nvidia_loaded {
+                eprintln!(
+                    "[sone] NVIDIA detected on Wayland; setting \
+                     WEBKIT_DISABLE_DMABUF_RENDERER=1 to avoid WebKitGTK \
+                     GBM allocation failure. Pre-set the variable to override."
+                );
+                std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
             }
         }
     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,18 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    #[cfg(target_os = "linux")]
+    {
+        // NVIDIA GPUs can't allocate GBM buffers for WebKitGTK's DMA-BUF
+        // renderer on Wayland.
+        // Shared-memory fallback works fine.
+        if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
+            if let Ok(modules) = std::fs::read_to_string("/proc/modules") {
+                if modules.contains("nvidia") {
+                    std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+                }
+            }
+        }
+    }
     tauri_app_lib::run()
 }


### PR DESCRIPTION
NVIDIA GPUs fail to allocate GBM buffers for DMA-BUF rendering in WebKitGTK on Wayland
We can detect NVIDIA via `/proc/modules` and set `WEBKIT_DISABLE_DMABUF_RENDERER=1` to use shared-memory buffers instead.

Should resolve #87 

(Edit: And should resolve the issue without the expense of disabling compositing completely.)