### PR TITLE
Pagination for 'View all' pages

### DIFF
--- a/src-tauri/src/commands/pages.rs
+++ b/src-tauri/src/commands/pages.rs
@@ -813,7 +813,7 @@ pub async fn get_artist_view_all(
     limit: u32,
 ) -> Result<Value, SoneError> {
     log::debug!(
-        "[get_artist_view_all]: artist_id={} path={} offset={} limit={}",
+        "[get_artist_view_all]: artist_id={}, path={}, offset={}, limit={}",
         artist_id,
         view_all_path,
         offset,

--- a/src-tauri/src/commands/pages.rs
+++ b/src-tauri/src/commands/pages.rs
@@ -809,14 +809,21 @@ pub async fn get_artist_view_all(
     app_handle: tauri::AppHandle,
     artist_id: u64,
     view_all_path: String,
+    offset: u32,
+    limit: u32,
 ) -> Result<Value, SoneError> {
     log::debug!(
-        "[get_artist_view_all]: artist_id={}, path={}",
+        "[get_artist_view_all]: artist_id={} path={} offset={} limit={}",
         artist_id,
-        view_all_path
+        view_all_path,
+        offset,
+        limit
     );
 
-    let cache_key = format!("artist-view-all:{}:{}", artist_id, view_all_path);
+    let cache_key = format!(
+        "artist-view-all:{}:{}:{}:{}",
+        artist_id, view_all_path, offset, limit
+    );
     match state.disk_cache.get(&cache_key, CacheTier::Dynamic).await {
         CacheResult::Fresh(bytes) => {
             if let Ok(data) = serde_json::from_slice(&bytes) {
@@ -835,7 +842,9 @@ pub async fn get_artist_view_all(
                             let st = handle.state::<AppState>();
                             let result = {
                                 let mut client = st.tidal_client.lock().await;
-                                client.get_artist_view_all(artist_id, &path).await
+                                client
+                                    .get_artist_view_all(artist_id, &path, offset, limit)
+                                    .await
                             };
                             if let Ok(fresh) = result {
                                 if let Ok(json) = serde_json::to_vec(&fresh) {
@@ -864,7 +873,7 @@ pub async fn get_artist_view_all(
 
     let mut client = state.tidal_client.lock().await;
     let data = client
-        .get_artist_view_all(artist_id, &view_all_path)
+        .get_artist_view_all(artist_id, &view_all_path, offset, limit)
         .await?;
     drop(client);
 

--- a/src-tauri/src/tidal_api.rs
+++ b/src-tauri/src/tidal_api.rs
@@ -4488,9 +4488,13 @@ impl TidalClient {
         &mut self,
         artist_id: u64,
         view_all_path: &str,
+        offset: u32,
+        limit: u32,
     ) -> Result<Value, SoneError> {
         let cc = self.country_code.clone();
         let id_str = artist_id.to_string();
+        let limit_str = limit.to_string();
+        let offset_str = offset.to_string();
         // viewAll paths from v2 API are relative like "artist/ARTIST_ALBUMS/view-all?artistId=123"
         // They need the v2 base URL, and may already contain query params
         let url = if view_all_path.starts_with("http") {
@@ -4509,8 +4513,8 @@ impl TidalClient {
                     ("countryCode", &cc),
                     ("deviceType", "BROWSER"),
                     ("platform", "WEB"),
-                    ("limit", "50"),
-                    ("offset", "0"),
+                    ("limit", &limit_str),
+                    ("offset", &offset_str),
                 ],
             )
             .await?;

--- a/src/api/tidal.ts
+++ b/src/api/tidal.ts
@@ -597,20 +597,29 @@ function parseArtistPageV1(json: any): ArtistPageData {
 export async function getArtistViewAll(
   artistId: number,
   viewAllPath: string,
-): Promise<any[]> {
-  return cached(
-    `artist-view-all:${artistId}:${viewAllPath}`,
-    ["artist"],
-    async () => {
-      const raw = await invoke<any>("get_artist_view_all", {
-        artistId,
-        viewAllPath,
-      });
-      const items = raw?.items || [];
-      return items.map((item: any) => item.data || item);
-    },
-    TTL.MEDIUM,
-  );
+  offset: number = 0,
+  limit: number = 50,
+): Promise<{ items: any[]; hasMore: boolean }> {
+  const fetcher = async () => {
+    const raw = await invoke<any>("get_artist_view_all", {
+      artistId,
+      viewAllPath,
+      offset,
+      limit,
+    });
+    const rawItems = raw?.items || [];
+    const items = rawItems.map((item: any) => item.data || item);
+    return { items, hasMore: items.length >= limit };
+  };
+  if (offset === 0) {
+    return cached(
+      `artist-view-all:${artistId}:${viewAllPath}`,
+      ["artist"],
+      fetcher,
+      TTL.MEDIUM,
+    );
+  }
+  return fetcher();
 }
 
 export async function getArtistTopTracksAll(

--- a/src/components/MediaGrid.tsx
+++ b/src/components/MediaGrid.tsx
@@ -15,16 +15,23 @@ export default function MediaGrid({ children }: MediaGridProps) {
   );
 }
 
+/** Single skeleton card for the media grid. */
+export function MediaCardSkeleton() {
+  return (
+    <div className="p-3">
+      <div className="aspect-square bg-th-surface-hover rounded-md animate-pulse mb-2" />
+      <div className="h-4 w-3/4 bg-th-surface-hover rounded animate-pulse mb-1" />
+      <div className="h-3 w-1/2 bg-th-surface-hover rounded animate-pulse" />
+    </div>
+  );
+}
+
 /** Loading skeleton for the media grid. */
 export function MediaGridSkeleton({ count = 18 }: { count?: number }) {
   return (
     <MediaGrid>
       {Array.from({ length: count }).map((_, i) => (
-        <div key={i} className="p-3">
-          <div className="aspect-square bg-th-surface-hover rounded-md animate-pulse mb-2" />
-          <div className="h-4 w-3/4 bg-th-surface-hover rounded animate-pulse mb-1" />
-          <div className="h-3 w-1/2 bg-th-surface-hover rounded animate-pulse" />
-        </div>
+        <MediaCardSkeleton key={i} />
       ))}
     </MediaGrid>
   );

--- a/src/components/ViewAllPage.tsx
+++ b/src/components/ViewAllPage.tsx
@@ -12,6 +12,7 @@ import MediaGrid, {
   MediaGridSkeleton,
   MediaGridError,
   MediaGridEmpty,
+  MediaCardSkeleton,
 } from "./MediaGrid";
 import PageContainer from "./PageContainer";
 import {
@@ -24,6 +25,8 @@ import {
   isMixItem,
   buildMediaItem,
 } from "../utils/itemHelpers";
+
+const PAGE_SIZE = 50;
 
 interface ViewAllPageProps {
   title: string;
@@ -62,8 +65,12 @@ export default function ViewAllPage({
 
   const [items, setItems] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+  const [hasMore, setHasMore] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const hasLoadedRef = useRef(false);
+  const loadingMoreRef = useRef(false);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
 
   // Context menu state
   const [contextMenu, setContextMenu] = useState<{
@@ -90,8 +97,9 @@ export default function ViewAllPage({
     const loadData = async () => {
       try {
         if (artistId) {
-          const allItems = await getArtistViewAll(artistId, apiPath);
-          setItems(allItems);
+          const data = await getArtistViewAll(artistId, apiPath, 0, PAGE_SIZE);
+          setItems(data.items);
+          setHasMore(data.hasMore);
         } else {
           const result = await getPageSection(apiPath);
           const allItems = result.sections.flatMap((s) =>
@@ -108,6 +116,43 @@ export default function ViewAllPage({
 
     loadData();
   }, [apiPath, artistId]);
+
+  const handleLoadMore = useCallback(async () => {
+    if (loadingMoreRef.current || !hasMore || !artistId) return;
+    loadingMoreRef.current = true;
+    setLoadingMore(true);
+    try {
+      const data = await getArtistViewAll(
+        artistId,
+        apiPath,
+        items.length,
+        PAGE_SIZE,
+      );
+      setItems((prev) => [...prev, ...data.items]);
+      setHasMore(data.hasMore);
+    } catch (err) {
+      console.error("[ViewAllPage] load more error:", err);
+    } finally {
+      loadingMoreRef.current = false;
+      setLoadingMore(false);
+    }
+  }, [artistId, apiPath, items.length, hasMore]);
+
+  useEffect(() => {
+    if (!artistId) return;
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting && hasMore) {
+          handleLoadMore();
+        }
+      },
+      { rootMargin: "200px" },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [artistId, hasMore, handleLoadMore]);
 
   const handleItemClick = (item: any) => {
     if (isTrackItem(item)) {
@@ -251,7 +296,16 @@ export default function ViewAllPage({
                 />
               );
             })}
+            {artistId &&
+              loadingMore &&
+              Array.from({ length: 6 }).map((_, i) => (
+                <MediaCardSkeleton key={`sk-${i}`} />
+              ))}
           </MediaGrid>
+        )}
+
+        {artistId && hasMore && !loading && !error && items.length > 0 && (
+          <div ref={sentinelRef} aria-hidden className="h-px" />
         )}
 
         {/* Media context menu */}


### PR DESCRIPTION
`View all` on artist pages is currently limited to the first 50 entries. This change adds pagination, so that a user can scroll to all entries even if there are more than 50.

I tried to stay close to the existing implementation of pagination in the tracks list.

To see the behavior in action go to an artist page with more than 50 albums ("BBC Symphony Orchestra" is a good example as they have a lot), click on 'view all' in the albums section and scroll down.