### PR TITLE
feat: TIDAL play-reporting 

### DIFF
--- a/src-tauri/src/commands/metadata.rs
+++ b/src-tauri/src/commands/metadata.rs
@@ -17,7 +17,7 @@ pub async fn get_stream_url(
         quality
     );
     let mut client = state.tidal_client.lock().await;
-    client.get_stream_url(track_id, &quality).await
+    client.get_stream_url(track_id, &quality, None).await
 }
 
 #[tauri::command(rename_all = "camelCase")]

--- a/src-tauri/src/commands/playback.rs
+++ b/src-tauri/src/commands/playback.rs
@@ -37,29 +37,44 @@ pub async fn resolve_play_uri(
     // Without client_secret, skip Hi-Res (those credentials typically return
     // encrypted DASH streams that require Widevine). With a secret, the
     // confidential PKCE credentials may return unencrypted Hi-Res BTS streams.
+    let sid: Option<String> = if state
+        .report_playback_events
+        .load(std::sync::atomic::Ordering::Relaxed)
+    {
+        Some(uuid::Uuid::new_v4().to_string())
+    } else {
+        None
+    };
+
     let stream_info = {
         let mut client = state.tidal_client.lock().await;
         let has_secret = !client.client_secret.is_empty();
 
         if has_secret {
-            match client.get_stream_url(track_id, "HI_RES_LOSSLESS").await {
+            match client
+                .get_stream_url(track_id, "HI_RES_LOSSLESS", sid.as_deref())
+                .await
+            {
                 Ok(info) => info,
                 Err(e) if e.is_network() => return Err(e),
-                Err(_) => match client.get_stream_url(track_id, "HI_RES").await {
+                Err(_) => match client.get_stream_url(track_id, "HI_RES", sid.as_deref()).await {
                     Ok(info) => info,
                     Err(e) if e.is_network() => return Err(e),
-                    Err(_) => match client.get_stream_url(track_id, "LOSSLESS").await {
+                    Err(_) => match client
+                        .get_stream_url(track_id, "LOSSLESS", sid.as_deref())
+                        .await
+                    {
                         Ok(info) => info,
                         Err(e) if e.is_network() => return Err(e),
-                        Err(_) => client.get_stream_url(track_id, "HIGH").await?,
+                        Err(_) => client.get_stream_url(track_id, "HIGH", sid.as_deref()).await?,
                     },
                 },
             }
         } else {
-            match client.get_stream_url(track_id, "LOSSLESS").await {
+            match client.get_stream_url(track_id, "LOSSLESS", sid.as_deref()).await {
                 Ok(info) => info,
                 Err(e) if e.is_network() => return Err(e),
-                Err(_) => client.get_stream_url(track_id, "HIGH").await?,
+                Err(_) => client.get_stream_url(track_id, "HIGH", sid.as_deref()).await?,
             }
         }
     };

--- a/src-tauri/src/commands/scrobble.rs
+++ b/src-tauri/src/commands/scrobble.rs
@@ -29,6 +29,14 @@ pub struct TrackStartedPayload {
     pub chosen_by_user: bool,
     pub isrc: Option<String>,
     pub track_id: Option<u64>,
+    #[serde(default)]
+    pub streaming_session_id: Option<String>,
+    #[serde(default)]
+    pub source_type: Option<String>,
+    #[serde(default)]
+    pub source_id: Option<String>,
+    #[serde(default)]
+    pub quality: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -40,6 +48,17 @@ pub async fn notify_track_started(
     state: State<'_, AppState>,
     payload: TrackStartedPayload,
 ) -> Result<(), SoneError> {
+    let report_params = crate::playback_report::StartParams {
+        session_id: payload.streaming_session_id.clone().unwrap_or_default(),
+        product_id: payload.track_id.map(|id| id.to_string()).unwrap_or_default(),
+        quality: payload
+            .quality
+            .clone()
+            .unwrap_or_else(|| "LOSSLESS".to_string()),
+        source_type: payload.source_type.clone(),
+        source_id: payload.source_id.clone(),
+        duration_secs: payload.duration_secs,
+    };
     let track = ScrobbleTrack {
         artist: payload.artist,
         track: payload.title,
@@ -56,18 +75,23 @@ pub async fn notify_track_started(
         artist_mbids: Vec::new(),
     };
     state.scrobble_manager.on_track_started(track).await;
+    if let Some(event) = state.report_manager.on_track_started(report_params).await {
+        post_play_event(state.inner(), event).await;
+    }
     Ok(())
 }
 
 #[tauri::command(rename_all = "camelCase")]
 pub async fn notify_track_paused(state: State<'_, AppState>) -> Result<(), SoneError> {
     state.scrobble_manager.on_pause().await;
+    state.report_manager.on_pause().await;
     Ok(())
 }
 
 #[tauri::command(rename_all = "camelCase")]
 pub async fn notify_track_resumed(state: State<'_, AppState>) -> Result<(), SoneError> {
     state.scrobble_manager.on_resume().await;
+    state.report_manager.on_resume().await;
     Ok(())
 }
 
@@ -80,6 +104,9 @@ pub async fn notify_track_seeked(state: State<'_, AppState>) -> Result<(), SoneE
 #[tauri::command(rename_all = "camelCase")]
 pub async fn notify_track_stopped(state: State<'_, AppState>) -> Result<(), SoneError> {
     state.scrobble_manager.on_track_stopped().await;
+    if let Some(event) = state.report_manager.on_track_stopped().await {
+        post_play_event(state.inner(), event).await;
+    }
     Ok(())
 }
 
@@ -276,4 +303,17 @@ pub async fn complete_audioscrobbler_auth(
         .await;
 
     Ok(username)
+}
+
+/// Finalized-session helper: POST a playback_session event, log the result.
+async fn post_play_event(state: &AppState, event: serde_json::Value) {
+    let mut client = state.tidal_client.lock().await;
+    match client.report_playback_session(&event).await {
+        Ok((status, body)) => log::info!(
+            "[play-report] event-batch HTTP {} (sender_fault={})",
+            status,
+            body.contains("SenderFault")
+        ),
+        Err(e) => log::warn!("[play-report] event-batch failed: {e}"),
+    }
 }

--- a/src-tauri/src/commands/utility.rs
+++ b/src-tauri/src/commands/utility.rs
@@ -229,6 +229,24 @@ pub fn set_gapless(state: State<'_, AppState>, enabled: bool) -> Result<(), Sone
 }
 
 #[tauri::command]
+pub fn get_report_playback_events(state: State<'_, AppState>) -> bool {
+    state.report_playback_events.load(Ordering::Relaxed)
+}
+
+#[tauri::command]
+pub fn set_report_playback_events(
+    state: State<'_, AppState>,
+    enabled: bool,
+) -> Result<(), SoneError> {
+    state.report_playback_events.store(enabled, Ordering::Relaxed);
+    state.report_manager.set_enabled(enabled);
+    let mut settings = state.load_settings().unwrap_or_default();
+    settings.report_playback_events = enabled;
+    state.save_settings(&settings)?;
+    Ok(())
+}
+
+#[tauri::command]
 pub fn get_exclusive_device(state: State<'_, AppState>) -> Option<String> {
     state.exclusive_device.lock().unwrap().clone()
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod idle_inhibit;
 pub mod logging;
 #[cfg(target_os = "linux")]
 mod mpris;
+mod playback_report;
 mod scrobble;
 mod signal_path;
 mod pipeline_probe;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -143,6 +143,8 @@ pub struct Settings {
     pub bit_perfect: bool,
     #[serde(default = "defaults::yes")]
     pub gapless: bool,
+    #[serde(default = "defaults::yes")]
+    pub report_playback_events: bool,
     #[serde(default)]
     pub scrobble: ScrobbleSettings,
     #[serde(default)]
@@ -182,6 +184,7 @@ impl Default for Settings {
             exclusive_device: None,
             bit_perfect: false,
             gapless: true,
+            report_playback_events: true,
             scrobble: Default::default(),
             proxy: Default::default(),
             discord_rpc: true,
@@ -208,6 +211,8 @@ pub struct AppState {
     pub exclusive_mode: AtomicBool,
     pub bit_perfect: AtomicBool,
     pub gapless: AtomicBool,
+    pub report_playback_events: std::sync::atomic::AtomicBool,
+    pub report_manager: std::sync::Arc<crate::playback_report::PlaybackReporter>,
     pub exclusive_device: std::sync::Mutex<Option<String>>,
     pub cached_audio_devices: std::sync::Mutex<Option<Vec<AudioDevice>>>,
     /// Current track's selected replay gain (dB) stored as f64 bits. NAN = no data.
@@ -320,6 +325,10 @@ impl AppState {
         let exclusive_mode = saved.as_ref().map(|s| s.exclusive_mode).unwrap_or(false);
         let bit_perfect = saved.as_ref().map(|s| s.bit_perfect).unwrap_or(false);
         let gapless = saved.as_ref().map(|s| s.gapless).unwrap_or(true);
+        let report_playback_events = saved
+            .as_ref()
+            .map(|s| s.report_playback_events)
+            .unwrap_or(true);
         let exclusive_device = saved.as_ref().and_then(|s| s.exclusive_device.clone());
 
         let proxy_settings = saved.as_ref().map(|s| s.proxy.clone()).unwrap_or_default();
@@ -377,6 +386,10 @@ impl AppState {
             exclusive_mode: AtomicBool::new(exclusive_mode),
             bit_perfect: AtomicBool::new(bit_perfect),
             gapless: AtomicBool::new(gapless),
+            report_playback_events: std::sync::atomic::AtomicBool::new(report_playback_events),
+            report_manager: std::sync::Arc::new(
+                crate::playback_report::PlaybackReporter::new(report_playback_events),
+            ),
             exclusive_device: std::sync::Mutex::new(exclusive_device),
             cached_audio_devices: std::sync::Mutex::new(None),
             last_replay_gain: AtomicU64::new(f64::NAN.to_bits()),
@@ -944,6 +957,8 @@ pub fn run() {
             commands::utility::get_gapless,
             commands::utility::get_gapless_supported,
             commands::utility::set_gapless,
+            commands::utility::get_report_playback_events,
+            commands::utility::set_report_playback_events,
             commands::utility::get_exclusive_device,
             commands::utility::set_exclusive_device,
             commands::utility::list_audio_devices,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -990,6 +990,10 @@ pub fn run() {
                 tauri::async_runtime::block_on(async {
                     state.idle_inhibitor.lock().await.uninhibit().await;
                     state.scrobble_manager.flush().await;
+                    if let Some(event) = state.report_manager.on_track_stopped().await {
+                        let mut client = state.tidal_client.lock().await;
+                        let _ = client.report_playback_session(&event).await;
+                    }
                 });
             }
         });

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -233,6 +233,15 @@ pub fn now_secs() -> u64 {
         .as_secs()
 }
 
+/// Wall-clock milliseconds since the Unix epoch.
+pub fn now_millis() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
 impl AppState {
     fn new(app_handle: tauri::AppHandle) -> Self {
         // Get config dir

--- a/src-tauri/src/playback_report/event.rs
+++ b/src-tauri/src/playback_report/event.rs
@@ -167,4 +167,16 @@ mod tests {
         assert_eq!(v["uuid"], "uuid-1");
         assert_eq!(v["payload"]["playbackSessionId"], "s");
     }
+
+    #[test]
+    fn headers_json_uses_bare_token_and_required_keys() {
+        let h = build_headers_json("my-cid", "raw-token", 1700);
+        let v: serde_json::Value = serde_json::from_str(&h).unwrap();
+        assert_eq!(v["client-id"], "my-cid");
+        assert_eq!(v["consent-category"], "NECESSARY");
+        assert_eq!(v["authorization"], "raw-token"); // bare, no "Bearer "
+        assert_eq!(v["requested-sent-timestamp"], 1700i64);
+        assert!(v.get("app-name").is_some());
+        assert!(v.get("os-name").is_some());
+    }
 }

--- a/src-tauri/src/playback_report/event.rs
+++ b/src-tauri/src/playback_report/event.rs
@@ -1,0 +1,170 @@
+use serde_json::{json, Value};
+
+/// Map SONE's quality tiers to the TIDAL event enum (LOW/HIGH/LOSSLESS/HI_RES_LOSSLESS).
+/// Avoids `HI_RES` (web/iOS-only; Android omits it) — fold it into HI_RES_LOSSLESS.
+pub fn map_quality(q: &str) -> &'static str {
+    match q {
+        "LOW" => "LOW",
+        "HIGH" => "HIGH",
+        "LOSSLESS" => "LOSSLESS",
+        "HI_RES" | "HI_RES_LOSSLESS" => "HI_RES_LOSSLESS",
+        _ => "LOSSLESS",
+    }
+}
+
+/// Build the PlayLog `playback_session` payload. Timestamps are epoch ms;
+/// asset positions are seconds (float). Product ids are strings.
+#[allow(clippy::too_many_arguments)]
+pub fn build_playback_session_payload(
+    session_id: &str,
+    product_id: &str,
+    quality: &str,
+    source_type: Option<&str>,
+    source_id: Option<&str>,
+    start_ms: i64,
+    start_pos: f64,
+    end_ms: i64,
+    end_pos: f64,
+) -> Value {
+    json!({
+        "playbackSessionId": session_id,
+        "startTimestamp": start_ms,
+        "startAssetPosition": start_pos,
+        "isPostPaywall": true,
+        "productType": "TRACK",
+        "requestedProductId": product_id,
+        "actualProductId": product_id,
+        "actualAssetPresentation": "FULL",
+        "actualAudioMode": "STEREO",
+        "actualQuality": map_quality(quality),
+        "sourceType": source_type,
+        "sourceId": source_id,
+        "actions": [
+            { "actionType": "PLAYBACK_START", "timestamp": start_ms, "assetPosition": start_pos },
+            { "actionType": "PLAYBACK_STOP",  "timestamp": end_ms,   "assetPosition": end_pos },
+        ],
+        "endTimestamp": end_ms,
+        "endAssetPosition": end_pos,
+    })
+}
+
+/// The MessageBody envelope: `{group, name, payload, ts, uuid, version}` (stringified).
+pub fn build_message_body(name: &str, payload: &Value, ts_ms: i64, uuid: &str) -> String {
+    json!({
+        "group": "play_log",
+        "name": name,
+        "payload": payload,
+        "version": 2,
+        "ts": ts_ms,
+        "uuid": uuid,
+    })
+    .to_string()
+}
+
+/// The per-event `Headers` map (stringified). `authorization` is the BARE token (no Bearer).
+pub fn build_headers_json(client_id: &str, bare_token: &str, ts_ms: i64) -> String {
+    json!({
+        "app-name": "TIDAL_ANDROID",
+        "app-version": "2.92.0",
+        "client-id": client_id,
+        "consent-category": "NECESSARY",
+        "os-name": "ANDROID",
+        "requested-sent-timestamp": ts_ms,
+        "authorization": bare_token,
+    })
+    .to_string()
+}
+
+/// Build the SQS SendMessageBatch form pairs for a single event (1-based, no Action/Version).
+pub fn build_event_batch_form(
+    id: &str,
+    name: &str,
+    message_body: &str,
+    headers_json: &str,
+) -> Vec<(String, String)> {
+    let e = "SendMessageBatchRequestEntry.1";
+    vec![
+        (format!("{e}.Id"), id.to_string()),
+        (format!("{e}.MessageBody"), message_body.to_string()),
+        (format!("{e}.MessageAttribute.1.Name"), "Name".to_string()),
+        (format!("{e}.MessageAttribute.1.Value.StringValue"), name.to_string()),
+        (format!("{e}.MessageAttribute.1.Value.DataType"), "String".to_string()),
+        (format!("{e}.MessageAttribute.2.Name"), "Headers".to_string()),
+        (format!("{e}.MessageAttribute.2.Value.StringValue"), headers_json.to_string()),
+        (format!("{e}.MessageAttribute.2.Value.DataType"), "String".to_string()),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn payload_has_correct_units_and_types() {
+        let p = build_playback_session_payload(
+            "sess-1", "12345", "LOSSLESS",
+            Some("ALBUM"), Some("999"),
+            1_000_000, 0.0, 1_195_000, 195.0,
+        );
+        assert_eq!(p["playbackSessionId"], "sess-1");
+        assert_eq!(p["productType"], "TRACK");
+        assert_eq!(p["requestedProductId"], "12345");
+        assert_eq!(p["actualProductId"], "12345");
+        assert_eq!(p["isPostPaywall"], true);
+        assert_eq!(p["actualAssetPresentation"], "FULL");
+        assert_eq!(p["actualAudioMode"], "STEREO");
+        assert_eq!(p["actualQuality"], "LOSSLESS");
+        assert_eq!(p["sourceType"], "ALBUM");
+        assert_eq!(p["sourceId"], "999");
+        assert_eq!(p["startTimestamp"], 1_000_000i64);
+        assert_eq!(p["startAssetPosition"], 0.0);
+        assert_eq!(p["endTimestamp"], 1_195_000i64);
+        assert_eq!(p["endAssetPosition"], 195.0);
+        let actions = p["actions"].as_array().unwrap();
+        assert_eq!(actions.len(), 2);
+        assert_eq!(actions[0]["actionType"], "PLAYBACK_START");
+        assert_eq!(actions[0]["assetPosition"], 0.0);
+        assert_eq!(actions[1]["actionType"], "PLAYBACK_STOP");
+        assert_eq!(actions[1]["assetPosition"], 195.0);
+    }
+
+    #[test]
+    fn quality_maps_to_valid_enum() {
+        assert_eq!(map_quality("HI_RES_LOSSLESS"), "HI_RES_LOSSLESS");
+        assert_eq!(map_quality("HI_RES"), "HI_RES_LOSSLESS");
+        assert_eq!(map_quality("LOSSLESS"), "LOSSLESS");
+        assert_eq!(map_quality("HIGH"), "HIGH");
+        assert_eq!(map_quality("LOW"), "LOW");
+        assert_eq!(map_quality("garbage"), "LOSSLESS");
+    }
+
+    #[test]
+    fn sqs_form_has_one_based_entry_and_two_attributes() {
+        let pairs = build_event_batch_form("evt-id", "playback_session", "{\"body\":1}", "{\"h\":2}");
+        let map: std::collections::HashMap<_, _> = pairs.iter().cloned().collect();
+        assert_eq!(map["SendMessageBatchRequestEntry.1.Id"], "evt-id");
+        assert_eq!(map["SendMessageBatchRequestEntry.1.MessageBody"], "{\"body\":1}");
+        assert_eq!(map["SendMessageBatchRequestEntry.1.MessageAttribute.1.Name"], "Name");
+        assert_eq!(map["SendMessageBatchRequestEntry.1.MessageAttribute.1.Value.StringValue"], "playback_session");
+        assert_eq!(map["SendMessageBatchRequestEntry.1.MessageAttribute.1.Value.DataType"], "String");
+        assert_eq!(map["SendMessageBatchRequestEntry.1.MessageAttribute.2.Name"], "Headers");
+        assert_eq!(map["SendMessageBatchRequestEntry.1.MessageAttribute.2.Value.StringValue"], "{\"h\":2}");
+        assert_eq!(map["SendMessageBatchRequestEntry.1.MessageAttribute.2.Value.DataType"], "String");
+        assert!(!map.contains_key("Action"));
+        assert!(!map.contains_key("Version"));
+    }
+
+    #[test]
+    fn message_body_envelope_shape() {
+        let payload = json!({"playbackSessionId": "s"});
+        let body = build_message_body("playback_session", &payload, 1234, "uuid-1");
+        let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["group"], "play_log");
+        assert_eq!(v["name"], "playback_session");
+        assert_eq!(v["version"], 2);
+        assert_eq!(v["ts"], 1234i64);
+        assert_eq!(v["uuid"], "uuid-1");
+        assert_eq!(v["payload"]["playbackSessionId"], "s");
+    }
+}

--- a/src-tauri/src/playback_report/mod.rs
+++ b/src-tauri/src/playback_report/mod.rs
@@ -1,0 +1,1 @@
+pub mod event;

--- a/src-tauri/src/playback_report/mod.rs
+++ b/src-tauri/src/playback_report/mod.rs
@@ -1,2 +1,110 @@
 pub mod event;
 pub mod session;
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
+use serde_json::Value;
+use tokio::sync::Mutex;
+
+use session::{PlaybackSession, SessionParams};
+
+/// Inputs the frontend supplies when a track starts.
+pub struct StartParams {
+    pub session_id: String,
+    pub product_id: String,
+    pub quality: String,
+    pub source_type: Option<String>,
+    pub source_id: Option<String>,
+    pub duration_secs: u32,
+}
+
+pub struct PlaybackReporter {
+    current: Mutex<Option<PlaybackSession>>,
+    enabled: AtomicBool,
+}
+
+impl PlaybackReporter {
+    pub fn new(enabled: bool) -> Self {
+        Self { current: Mutex::new(None), enabled: AtomicBool::new(enabled) }
+    }
+
+    pub fn set_enabled(&self, on: bool) {
+        self.enabled.store(on, Ordering::Relaxed);
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.enabled.load(Ordering::Relaxed)
+    }
+
+    /// Finalize the previous session (if any) and open a new one.
+    /// Returns the previous session's `playback_session` payload to POST.
+    pub async fn on_track_started(&self, p: StartParams) -> Option<Value> {
+        if !self.is_enabled() {
+            *self.current.lock().await = None;
+            return None;
+        }
+        if p.session_id.is_empty() {
+            *self.current.lock().await = None;
+            return None;
+        }
+        let mut current = self.current.lock().await;
+        let prev = current.as_mut().map(|s| s.finalize());
+        *current = Some(PlaybackSession::new(SessionParams {
+            session_id: p.session_id,
+            product_id: p.product_id,
+            quality: p.quality,
+            source_type: p.source_type,
+            source_id: p.source_id,
+            duration_secs: p.duration_secs,
+            start_ms: crate::now_millis(),
+            start_instant: Instant::now(),
+        }));
+        prev
+    }
+
+    pub async fn on_pause(&self) {
+        if let Some(s) = self.current.lock().await.as_mut() { s.pause(); }
+    }
+
+    pub async fn on_resume(&self) {
+        if let Some(s) = self.current.lock().await.as_mut() { s.resume(); }
+    }
+
+    /// Finalize and clear the current session (explicit stop / app exit).
+    pub async fn on_track_stopped(&self) -> Option<Value> {
+        self.current.lock().await.take().map(|mut s| s.finalize())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn started_then_started_finalizes_previous() {
+        let r = PlaybackReporter::new(true);
+        assert!(r.on_track_started(params("s1", "100")).await.is_none());
+        let prev = r.on_track_started(params("s2", "200")).await;
+        let prev = prev.expect("should finalize previous session");
+        assert_eq!(prev["playbackSessionId"], "s1");
+        assert_eq!(prev["actualProductId"], "100");
+    }
+
+    #[tokio::test]
+    async fn disabled_reporter_emits_nothing() {
+        let r = PlaybackReporter::new(false);
+        assert!(r.on_track_started(params("s1", "100")).await.is_none());
+        assert!(r.on_track_stopped().await.is_none());
+    }
+
+    fn params(sid: &str, pid: &str) -> StartParams {
+        StartParams {
+            session_id: sid.to_string(),
+            product_id: pid.to_string(),
+            quality: "LOSSLESS".to_string(),
+            source_type: None,
+            source_id: None,
+            duration_secs: 100,
+        }
+    }
+}

--- a/src-tauri/src/playback_report/mod.rs
+++ b/src-tauri/src/playback_report/mod.rs
@@ -1,1 +1,2 @@
 pub mod event;
+pub mod session;

--- a/src-tauri/src/playback_report/mod.rs
+++ b/src-tauri/src/playback_report/mod.rs
@@ -71,7 +71,12 @@ impl PlaybackReporter {
     }
 
     /// Finalize and clear the current session (explicit stop / app exit).
+    /// If reporting is disabled, drop the in-flight session without emitting.
     pub async fn on_track_stopped(&self) -> Option<Value> {
+        if !self.is_enabled() {
+            *self.current.lock().await = None;
+            return None;
+        }
         self.current.lock().await.take().map(|mut s| s.finalize())
     }
 }

--- a/src-tauri/src/playback_report/session.rs
+++ b/src-tauri/src/playback_report/session.rs
@@ -1,0 +1,128 @@
+use std::time::Instant;
+use serde_json::Value;
+use crate::playback_report::event::build_playback_session_payload;
+
+pub struct SessionParams {
+    pub session_id: String,
+    pub product_id: String,
+    pub quality: String,
+    pub source_type: Option<String>,
+    pub source_id: Option<String>,
+    pub duration_secs: u32,
+    pub start_ms: i64,
+    pub start_instant: Instant,
+}
+
+pub struct PlaybackSession {
+    session_id: String,
+    product_id: String,
+    quality: String,
+    source_type: Option<String>,
+    source_id: Option<String>,
+    duration_secs: u32,
+    start_ms: i64,
+    pub start_instant: Instant,
+    accumulated: std::time::Duration,
+    segment_start: Option<Instant>,
+}
+
+impl PlaybackSession {
+    pub fn new(p: SessionParams) -> Self {
+        Self {
+            session_id: p.session_id,
+            product_id: p.product_id,
+            quality: p.quality,
+            source_type: p.source_type,
+            source_id: p.source_id,
+            duration_secs: p.duration_secs,
+            start_ms: p.start_ms,
+            start_instant: p.start_instant,
+            accumulated: std::time::Duration::ZERO,
+            segment_start: Some(p.start_instant),
+        }
+    }
+
+    pub fn pause_at(&mut self, now: Instant) {
+        if let Some(seg) = self.segment_start.take() {
+            self.accumulated += now.saturating_duration_since(seg);
+        }
+    }
+
+    pub fn resume_at(&mut self, now: Instant) {
+        if self.segment_start.is_none() {
+            self.segment_start = Some(now);
+        }
+    }
+
+    fn played_secs_at(&self, now: Instant) -> f64 {
+        let mut total = self.accumulated;
+        if let Some(seg) = self.segment_start {
+            total += now.saturating_duration_since(seg);
+        }
+        let secs = total.as_secs_f64();
+        let cap = self.duration_secs as f64;
+        if cap > 0.0 && secs > cap { cap } else { secs }
+    }
+
+    pub fn finalize_at(&mut self, end_ms: i64, now: Instant) -> Value {
+        let end_pos = self.played_secs_at(now);
+        build_playback_session_payload(
+            &self.session_id,
+            &self.product_id,
+            &self.quality,
+            self.source_type.as_deref(),
+            self.source_id.as_deref(),
+            self.start_ms,
+            0.0,
+            end_ms,
+            end_pos,
+        )
+    }
+
+    pub fn pause(&mut self) { self.pause_at(Instant::now()); }
+    pub fn resume(&mut self) { self.resume_at(Instant::now()); }
+
+    pub fn finalize(&mut self) -> Value {
+        let end_ms = crate::now_millis();
+        self.finalize_at(end_ms, Instant::now())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    fn mk() -> PlaybackSession {
+        PlaybackSession::new(SessionParams {
+            session_id: "s1".into(),
+            product_id: "100".into(),
+            quality: "LOSSLESS".into(),
+            source_type: Some("ALBUM".into()),
+            source_id: Some("55".into()),
+            duration_secs: 200,
+            start_ms: 1_000_000,
+            start_instant: Instant::now(),
+        })
+    }
+
+    #[test]
+    fn finalize_caps_position_at_duration() {
+        let mut s = mk();
+        let end = s.start_instant + Duration::from_secs(300);
+        let v = s.finalize_at(1_300_000, end);
+        assert_eq!(v["endAssetPosition"], 200.0);
+        assert_eq!(v["endTimestamp"], 1_300_000i64);
+        assert_eq!(v["startAssetPosition"], 0.0);
+    }
+
+    #[test]
+    fn pause_excludes_paused_time_from_position() {
+        let mut s = mk();
+        let t0 = s.start_instant;
+        s.pause_at(t0 + Duration::from_secs(10));
+        s.resume_at(t0 + Duration::from_secs(40));
+        let v = s.finalize_at(1_050_000, t0 + Duration::from_secs(50));
+        assert_eq!(v["endAssetPosition"], 20.0);
+    }
+}

--- a/src-tauri/src/playback_report/session.rs
+++ b/src-tauri/src/playback_report/session.rs
@@ -21,7 +21,6 @@ pub struct PlaybackSession {
     source_id: Option<String>,
     duration_secs: u32,
     start_ms: i64,
-    pub start_instant: Instant,
     accumulated: std::time::Duration,
     segment_start: Option<Instant>,
 }
@@ -36,7 +35,6 @@ impl PlaybackSession {
             source_id: p.source_id,
             duration_secs: p.duration_secs,
             start_ms: p.start_ms,
-            start_instant: p.start_instant,
             accumulated: std::time::Duration::ZERO,
             segment_start: Some(p.start_instant),
         }
@@ -93,8 +91,9 @@ mod tests {
     use super::*;
     use std::time::{Duration, Instant};
 
-    fn mk() -> PlaybackSession {
-        PlaybackSession::new(SessionParams {
+    fn mk() -> (PlaybackSession, Instant) {
+        let t0 = Instant::now();
+        let s = PlaybackSession::new(SessionParams {
             session_id: "s1".into(),
             product_id: "100".into(),
             quality: "LOSSLESS".into(),
@@ -102,14 +101,15 @@ mod tests {
             source_id: Some("55".into()),
             duration_secs: 200,
             start_ms: 1_000_000,
-            start_instant: Instant::now(),
-        })
+            start_instant: t0,
+        });
+        (s, t0)
     }
 
     #[test]
     fn finalize_caps_position_at_duration() {
-        let mut s = mk();
-        let end = s.start_instant + Duration::from_secs(300);
+        let (mut s, t0) = mk();
+        let end = t0 + Duration::from_secs(300);
         let v = s.finalize_at(1_300_000, end);
         assert_eq!(v["endAssetPosition"], 200.0);
         assert_eq!(v["endTimestamp"], 1_300_000i64);
@@ -118,8 +118,7 @@ mod tests {
 
     #[test]
     fn pause_excludes_paused_time_from_position() {
-        let mut s = mk();
-        let t0 = s.start_instant;
+        let (mut s, t0) = mk();
         s.pause_at(t0 + Duration::from_secs(10));
         s.resume_at(t0 + Duration::from_secs(40));
         let v = s.finalize_at(1_050_000, t0 + Duration::from_secs(50));

--- a/src-tauri/src/tidal_api.rs
+++ b/src-tauri/src/tidal_api.rs
@@ -499,6 +499,8 @@ pub struct StreamInfo {
     pub track_replay_gain: Option<f64>,
     #[serde(default)]
     pub track_peak_amplitude: Option<f64>,
+    #[serde(default)]
+    pub streaming_session_id: Option<String>,
 }
 
 // ==================== v2 Home Feed MIX types ====================
@@ -3070,17 +3072,22 @@ impl TidalClient {
         &mut self,
         track_id: u64,
         quality: &str,
+        streaming_session_id: Option<&str>,
     ) -> Result<StreamInfo, SoneError> {
         let cc = self.country_code.clone();
+        let mut params: Vec<(&str, &str)> = vec![
+            ("countryCode", &cc),
+            ("audioquality", quality),
+            ("playbackmode", "STREAM"),
+            ("assetpresentation", "FULL"),
+        ];
+        if let Some(sid) = streaming_session_id {
+            params.push(("streamingsessionid", sid));
+        }
         let body = self
             .api_get_body(
                 &format!("/tracks/{}/playbackinfopostpaywall", track_id),
-                &[
-                    ("countryCode", &cc),
-                    ("audioquality", quality),
-                    ("playbackmode", "STREAM"),
-                    ("assetpresentation", "FULL"),
-                ],
+                &params,
             )
             .await?;
 
@@ -3173,6 +3180,7 @@ impl TidalClient {
                 album_peak_amplitude: data.album_peak_amplitude,
                 track_replay_gain: data.track_replay_gain,
                 track_peak_amplitude: data.track_peak_amplitude,
+                streaming_session_id: streaming_session_id.map(|s| s.to_string()),
             });
         }
         // JSON fallback
@@ -3217,6 +3225,7 @@ impl TidalClient {
             album_peak_amplitude: data.album_peak_amplitude,
             track_replay_gain: data.track_replay_gain,
             track_peak_amplitude: data.track_peak_amplitude,
+            streaming_session_id: streaming_session_id.map(|s| s.to_string()),
         })
     }
 

--- a/src-tauri/src/tidal_api.rs
+++ b/src-tauri/src/tidal_api.rs
@@ -39,6 +39,7 @@ const TIDAL_AUTH_URL: &str = "https://auth.tidal.com/v1/oauth2";
 const TIDAL_API_URL: &str = "https://api.tidal.com/v1";
 const TIDAL_API_V2_URL: &str = "https://api.tidal.com/v2";
 const TIDAL_OPENAPI_URL: &str = "https://openapi.tidal.com/v2";
+const TIDAL_EVENT_URL: &str = "https://ec.tidal.com/api/event-batch";
 const TIDAL_CLIENT_VERSION: &str = "2025.11.3";
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -1023,6 +1024,55 @@ impl TidalClient {
 
         self.tokens = Some(new_tokens.clone());
         Ok(new_tokens)
+    }
+
+    /// POST a single `playback_session` event to the TIDAL Event Platform.
+    /// Returns the HTTP status + body so callers can log the SQS result.
+    /// NOTE (spike): holds the client lock for the duration; acceptable for the
+    /// fire-and-forget single-event spike. Harden with a cloned-token path later.
+    pub async fn report_playback_session(
+        &mut self,
+        payload: &serde_json::Value,
+    ) -> Result<(u16, String), SoneError> {
+        use crate::playback_report::event::{
+            build_event_batch_form, build_headers_json, build_message_body,
+        };
+        let tokens = self.tokens.as_ref().ok_or(SoneError::NotAuthenticated)?;
+        let mut access = tokens.access_token.clone();
+        let ts = crate::now_millis();
+        let evt_id = uuid::Uuid::new_v4().to_string();
+        let body = build_message_body("playback_session", payload, ts, &evt_id);
+        let headers = build_headers_json(&self.client_id, &access, ts);
+        let form = build_event_batch_form(&evt_id, "playback_session", &body, &headers);
+
+        let send = |client: reqwest::Client, token: String, form: Vec<(String, String)>| async move {
+            client
+                .post(TIDAL_EVENT_URL)
+                .header("Authorization", format!("Bearer {}", token))
+                .form(&form)
+                .send()
+                .await
+        };
+
+        let resp = send(self.client.clone(), access.clone(), form.clone()).await?;
+        if resp.status() == reqwest::StatusCode::UNAUTHORIZED {
+            self.refresh_token().await?;
+            access = self
+                .tokens
+                .as_ref()
+                .ok_or(SoneError::NotAuthenticated)?
+                .access_token
+                .clone();
+            let headers = build_headers_json(&self.client_id, &access, ts);
+            let form = build_event_batch_form(&evt_id, "playback_session", &body, &headers);
+            let resp = send(self.client.clone(), access, form).await?;
+            let status = resp.status().as_u16();
+            let text = resp.text().await.unwrap_or_default();
+            return Ok((status, text));
+        }
+        let status = resp.status().as_u16();
+        let text = resp.text().await.unwrap_or_default();
+        Ok((status, text))
     }
 
     /// Perform an authenticated GET, check status, and deserialize the JSON body.

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -200,6 +200,7 @@ export default function SettingsModal({ open, onClose }: SettingsModalProps) {
   );
   const [discordRpc, setDiscordRpc] = useState(false);
   const [discordStatusText, setDiscordStatusText] = useState("");
+  const [reportPlays, setReportPlays] = useState(true);
   const [decorations, setDecorations] = useAtom(decorationsAtom);
   const [hideTitleBar, setHideTitleBar] = useAtom(hideTitleBarAtom);
   const [minimizeToTray, setMinimizeToTray] = useState(false);
@@ -228,6 +229,9 @@ export default function SettingsModal({ open, onClose }: SettingsModalProps) {
       .catch(() => {});
     invoke<boolean>("get_discord_rpc")
       .then(setDiscordRpc)
+      .catch(() => {});
+    invoke<boolean>("get_report_playback_events")
+      .then(setReportPlays)
       .catch(() => {});
     invoke<boolean>("get_enable_logging")
       .then(setEnableLogging)
@@ -457,6 +461,38 @@ export default function SettingsModal({ open, onClose }: SettingsModalProps) {
                       />
                     </div>
                   )}
+
+                  {/* Report plays to TIDAL */}
+                  <div className="flex items-center justify-between py-3">
+                    <div className="flex items-center gap-3 min-w-0">
+                      <MessageSquare
+                        size={16}
+                        className="text-th-text-muted shrink-0"
+                      />
+                      <div>
+                        <p className="text-[13px] text-th-text-secondary">
+                          Report plays to TIDAL
+                        </p>
+                        <p className="text-[11px] text-th-text-muted">
+                          Let TIDAL register your plays (recently played, mixes).
+                          Experimental.
+                        </p>
+                      </div>
+                    </div>
+                    <button
+                      onClick={() => {
+                        const next = !reportPlays;
+                        setReportPlays(next);
+                        invoke("set_report_playback_events", {
+                          enabled: next,
+                        }).catch(() => {
+                          setReportPlays(!next);
+                        });
+                      }}
+                    >
+                      <Toggle on={reportPlays} />
+                    </button>
+                  </div>
                 </div>
               )}
 

--- a/src/hooks/usePlaybackActions.ts
+++ b/src/hooks/usePlaybackActions.ts
@@ -67,10 +67,7 @@ function normalizeTrack(raw: any): Track {
 }
 
 /** Map the playback-source type to a TIDAL play-log source type. */
-function mapSourceType(
-  type: string | undefined,
-  _mixType: string | undefined,
-): string | null {
+function mapSourceType(type: string | undefined): string | null {
   switch (type) {
     case "album":
       return "ALBUM";
@@ -106,7 +103,7 @@ function buildTrackStartedPayload(
     isrc: track.isrc || null,
     trackId: track.id || null,
     streamingSessionId: streamInfo?.streamingSessionId ?? null,
-    sourceType: mapSourceType(source?.type, source?.mixType),
+    sourceType: mapSourceType(source?.type),
     sourceId: source?.id != null ? String(source.id) : null,
     quality: streamInfo?.audioQuality ?? null,
   };

--- a/src/hooks/usePlaybackActions.ts
+++ b/src/hooks/usePlaybackActions.ts
@@ -39,7 +39,13 @@ import { stampQid, stampQids, ensureQid } from "../lib/qid";
 import { notifySeek, getInterpolatedPosition } from "../lib/playbackPosition";
 import { isTrackUnavailable, isUnplayableError } from "../lib/trackAvailability";
 import { pickGaplessNext } from "../lib/gaplessPredict";
-import type { Track, StreamInfo, ManualTrackSource, QueuedTrack } from "../types";
+import type {
+  Track,
+  StreamInfo,
+  ManualTrackSource,
+  QueuedTrack,
+  PlaybackSource,
+} from "../types";
 import { getTidalImageUrl } from "../types";
 import { preloadImage } from "../components/TidalImage";
 import { getTrackArtistDisplay, getTrackPrimaryArtist } from "../utils/itemHelpers";
@@ -60,10 +66,34 @@ function normalizeTrack(raw: any): Track {
   return track;
 }
 
+/** Map the playback-source type to a TIDAL play-log source type. */
+function mapSourceType(
+  type: string | undefined,
+  _mixType: string | undefined,
+): string | null {
+  switch (type) {
+    case "album":
+      return "ALBUM";
+    case "playlist":
+      return "PLAYLIST";
+    case "artist":
+      return "ARTIST";
+    case "mix":
+      return "MIX";
+    default:
+      return null;
+  }
+}
+
 /** Build the notify_track_started payload. Centralized so all call sites send the
  *  same fields — notably both `artist` (combined, for ListenBrainz) and
  *  `artistPrimary` (single primary, for Last.fm/Libre.fm). */
-function buildTrackStartedPayload(track: Track, chosenByUser: boolean) {
+function buildTrackStartedPayload(
+  track: Track,
+  chosenByUser: boolean,
+  streamInfo: StreamInfo | null | undefined,
+  source: PlaybackSource | null | undefined,
+) {
   return {
     artist: getTrackArtistDisplay(track),
     artistPrimary: getTrackPrimaryArtist(track),
@@ -75,6 +105,10 @@ function buildTrackStartedPayload(track: Track, chosenByUser: boolean) {
     chosenByUser,
     isrc: track.isrc || null,
     trackId: track.id || null,
+    streamingSessionId: streamInfo?.streamingSessionId ?? null,
+    sourceType: mapSourceType(source?.type, source?.mixType),
+    sourceId: source?.id != null ? String(source.id) : null,
+    quality: streamInfo?.audioQuality ?? null,
   };
 }
 
@@ -220,7 +254,12 @@ export function usePlaybackActions() {
 
         // Notify backend for scrobbling
         invoke("notify_track_started", {
-          payload: buildTrackStartedPayload(stamped, opts?.chosenByUser ?? true),
+          payload: buildTrackStartedPayload(
+            stamped,
+            opts?.chosenByUser ?? true,
+            info,
+            store.get(playbackSourceAtom),
+          ),
         }).catch(() => {});
         return { ok: true };
       } catch (error: any) {
@@ -283,7 +322,12 @@ export function usePlaybackActions() {
 
         // Notify backend so the replay is scrobbled
         invoke("notify_track_started", {
-          payload: buildTrackStartedPayload(track, true),
+          payload: buildTrackStartedPayload(
+            track,
+            true,
+            info,
+            store.get(playbackSourceAtom),
+          ),
         }).catch(() => {});
       } else {
         await invoke("resume_track");
@@ -351,7 +395,12 @@ export function usePlaybackActions() {
       store.set(isPlayingAtom, !store.get(userPausedAtom));
       store.set(consecutiveFailCountAtom, 0);
       invoke("notify_track_started", {
-        payload: buildTrackStartedPayload(stamped, false),
+        payload: buildTrackStartedPayload(
+          stamped,
+          false,
+          info,
+          store.get(playbackSourceAtom),
+        ),
       }).catch(() => {});
     },
     [store],
@@ -627,7 +676,12 @@ export function usePlaybackActions() {
             store.set(streamInfoAtom, info);
             store.set(isPlayingAtom, true);
             invoke("notify_track_started", {
-              payload: buildTrackStartedPayload(current, false),
+              payload: buildTrackStartedPayload(
+                current,
+                false,
+                info,
+                store.get(playbackSourceAtom),
+              ),
             }).catch(() => {});
           } catch (error: any) {
             console.error("Failed to repeat track:", error);
@@ -953,7 +1007,12 @@ export function usePlaybackActions() {
 
         // Notify backend for scrobbling
         invoke("notify_track_started", {
-          payload: buildTrackStartedPayload(prevTrack, true),
+          payload: buildTrackStartedPayload(
+            prevTrack,
+            true,
+            info,
+            store.get(playbackSourceAtom),
+          ),
         }).catch(() => {});
       } catch (error: any) {
         // Rollback all state
@@ -1050,7 +1109,12 @@ export function usePlaybackActions() {
 
             // Notify backend for scrobbling
             invoke("notify_track_started", {
-              payload: buildTrackStartedPayload(prevTrack, true),
+              payload: buildTrackStartedPayload(
+                prevTrack,
+                true,
+                info,
+                store.get(playbackSourceAtom),
+              ),
             }).catch(() => {});
           } catch (error: any) {
             // Rollback all state

--- a/src/types.ts
+++ b/src/types.ts
@@ -339,6 +339,7 @@ export interface StreamInfo {
   /** "application/dash+xml" | "application/vnd.tidal.bts" */
   manifestMimeType?: string;
   manifestHash?: string;
+  streamingSessionId?: string | null;
   trackId?: number;
   albumReplayGain?: number;
   albumPeakAmplitude?: number;


### PR DESCRIPTION
## Summary
Opt-in **Report plays to TIDAL** toggle (default on). On a full listen, sends a
`playback_session` event to TIDAL's Event Platform (`ec.tidal.com/api/event-batch`),
driven by the existing `notify_track_*` lifecycle with a `streamingSessionId` threaded
through the stream fetch.

## Status: does not work — TIDAL drops the tracking
- Events are **sent and accepted** (`HTTP 200`, no `SenderFault`) 
- Plays **never surface** in history. Attribution is gated on a **first-party player `client_id`**;
SONE's community `cid` can stream but isn't a recognized player, so `play_log` ignores the events.
- Legacy `et.tidal.com` (Option A) wouldn't help — same `cid`, same downstream gate.

## State
Pipeline complete, builds clean (0 warnings), 69 tests pass. Kept open as a correct reference.