### PR TITLE
fix: fall back to artist artwork and album covers for missing artist photos

### DIFF
--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -327,14 +327,8 @@ pub async fn poll_device_auth(
 pub async fn refresh_tidal_auth(state: State<'_, AppState>) -> Result<AuthTokens, SoneError> {
     log::debug!("[refresh_tidal_auth]");
     let mut client = state.tidal_client.lock().await;
-    let new_tokens = client.refresh_token().await?;
-
-    // Save refreshed tokens to settings
-    let mut settings = state.load_settings().unwrap_or_default();
-    settings.auth_tokens = Some(new_tokens.clone());
-    state.save_settings(&settings)?;
-
-    Ok(new_tokens)
+    // refresh_token persists the new tokens via the client's persist hook.
+    client.refresh_token().await
 }
 
 fn build_pkce_params(client_id: &str) -> PkceAuthParams {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,7 +29,7 @@ use cache::DiskCache;
 use crypto::Crypto;
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -253,6 +253,29 @@ pub fn now_secs() -> u64 {
         .as_secs()
 }
 
+/// Write refreshed tokens back into the stored settings. Called from every
+/// refresh, including the automatic one after a 401 — without it the stored
+/// access token stays stale and each launch burns a 401 before the first
+/// request succeeds.
+fn persist_auth_tokens(path: &Path, crypto: &Crypto, tokens: &AuthTokens) {
+    let mut settings = fs::read(path)
+        .ok()
+        .and_then(|data| crypto.decrypt(&data).ok())
+        .and_then(|plain| serde_json::from_slice::<Settings>(&plain).ok())
+        .unwrap_or_default();
+    settings.auth_tokens = Some(tokens.clone());
+
+    let write = || -> Result<(), SoneError> {
+        let json = serde_json::to_string_pretty(&settings)?;
+        let encrypted = crypto.encrypt(json.as_bytes())?;
+        fs::write(path, encrypted)?;
+        Ok(())
+    };
+    if let Err(e) = write() {
+        log::warn!("Failed to persist refreshed auth tokens: {e}");
+    }
+}
+
 impl AppState {
     fn new(app_handle: tauri::AppHandle) -> Self {
         // Get config dir
@@ -378,10 +401,19 @@ impl AppState {
             Arc::clone(&audio_player),
         ));
 
+        let mut tidal_client = TidalClient::new(&proxy_settings);
+        tidal_client.set_token_persist({
+            let settings_path = settings_path.clone();
+            let crypto = Arc::clone(&crypto);
+            Arc::new(move |tokens: &AuthTokens| {
+                persist_auth_tokens(&settings_path, &crypto, tokens);
+            })
+        });
+
         Self {
             audio_player,
             pipeline_probe,
-            tidal_client: Mutex::new(TidalClient::new(&proxy_settings)),
+            tidal_client: Mutex::new(tidal_client),
             settings_path,
             cache_dir,
             disk_cache,

--- a/src-tauri/src/mcp/sanitizer.rs
+++ b/src-tauri/src/mcp/sanitizer.rs
@@ -152,6 +152,8 @@ mod tests {
             id: 7,
             name: "Test Artist".to_string(),
             picture: None,
+            artwork_id: None,
+            selected_album_cover_fallback: None,
             artist_type: None,
             handle: None,
         };

--- a/src-tauri/src/tidal_api.rs
+++ b/src-tauri/src/tidal_api.rs
@@ -4,6 +4,7 @@ use crate::SoneError;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::sync::Arc;
 use std::time::Duration;
 
 /// Build a reqwest::Client with optional proxy configuration.
@@ -1064,6 +1065,9 @@ pub struct DeviceAuthResponse {
     pub interval: u64,
 }
 
+/// Invoked with freshly refreshed tokens so the caller can persist them.
+pub type TokenPersist = Arc<dyn Fn(&AuthTokens) + Send + Sync>;
+
 pub struct TidalClient {
     client: Client,
     pub tokens: Option<AuthTokens>,
@@ -1072,6 +1076,7 @@ pub struct TidalClient {
     /// The user's country code from their Tidal session (e.g. "US", "GB", "DE").
     /// Populated after authentication via get_session_info().
     pub country_code: String,
+    token_persist: Option<TokenPersist>,
 }
 
 impl TidalClient {
@@ -1087,7 +1092,13 @@ impl TidalClient {
             client_id: String::new(),
             client_secret: String::new(),
             country_code: "US".to_string(),
+            token_persist: None,
         }
+    }
+
+    /// Register the hook that writes refreshed tokens to disk.
+    pub fn set_token_persist(&mut self, persist: TokenPersist) {
+        self.token_persist = Some(persist);
     }
 
     pub fn set_credentials(&mut self, client_id: &str, client_secret: &str) {
@@ -1174,6 +1185,11 @@ impl TidalClient {
         };
 
         self.tokens = Some(new_tokens.clone());
+        // Persist immediately: the auto-refresh on 401 is the common path, and
+        // without this the stored token stays stale forever.
+        if let Some(persist) = &self.token_persist {
+            persist(&new_tokens);
+        }
         Ok(new_tokens)
     }
 

--- a/src-tauri/src/tidal_api.rs
+++ b/src-tauri/src/tidal_api.rs
@@ -320,6 +320,10 @@ pub struct TidalArtist {
     pub name: String,
     #[serde(default)]
     pub picture: Option<String>,
+    #[serde(default)]
+    pub artwork_id: Option<String>,
+    #[serde(default)]
+    pub selected_album_cover_fallback: Option<String>,
     /// "MAIN" | "FEATURED" — present on embedded artist refs in tracks/albums
     #[serde(default, rename = "type")]
     pub artist_type: Option<String>,
@@ -977,6 +981,10 @@ pub struct TidalArtistDetail {
     pub name: String,
     #[serde(default)]
     pub picture: Option<String>,
+    #[serde(default)]
+    pub artwork_id: Option<String>,
+    #[serde(default)]
+    pub selected_album_cover_fallback: Option<String>,
     #[serde(default)]
     pub handle: Option<String>,
     #[serde(default)]
@@ -6052,6 +6060,39 @@ mod home_tab_tests {
             "pagedList": { "items": [ { "header": "X", "artifactId": "1", "type": "PLAYLIST" } ] }
         });
         assert!(super::TidalClient::parse_v1_module(&module).is_some());
+    }
+
+    #[test]
+    fn artist_structs_carry_artwork_fallback_fields() {
+        let body = json!({
+            "id": 42,
+            "name": "Killigrew",
+            "picture": null,
+            "artworkId": "art-1",
+            "selectedAlbumCoverFallback": "cover-1"
+        })
+        .to_string();
+
+        let artist: TidalArtist = serde_json::from_str(&body).expect("parses");
+        assert_eq!(artist.picture, None);
+        assert_eq!(artist.artwork_id.as_deref(), Some("art-1"));
+        assert_eq!(
+            artist.selected_album_cover_fallback.as_deref(),
+            Some("cover-1")
+        );
+
+        let detail: TidalArtistDetail = serde_json::from_str(&body).expect("parses");
+        assert_eq!(detail.artwork_id.as_deref(), Some("art-1"));
+        assert_eq!(
+            detail.selected_album_cover_fallback.as_deref(),
+            Some("cover-1")
+        );
+
+        // Absent fields must not fail the parse.
+        let bare = json!({ "id": 1, "name": "Bare" }).to_string();
+        let bare_artist: TidalArtist = serde_json::from_str(&bare).expect("parses");
+        assert_eq!(bare_artist.artwork_id, None);
+        assert_eq!(bare_artist.selected_album_cover_fallback, None);
     }
 }
 

--- a/src-tauri/src/tidal_api.rs
+++ b/src-tauri/src/tidal_api.rs
@@ -761,6 +761,10 @@ pub struct DirectHitItem {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub picture: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub artwork_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_album_cover_fallback: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cover: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub image: Option<String>,
@@ -802,6 +806,14 @@ impl DirectHitItem {
                     .get("picture")
                     .and_then(|v| v.as_str())
                     .map(String::from),
+                artwork_id: val
+                    .get("artworkId")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                selected_album_cover_fallback: val
+                    .get("selectedAlbumCoverFallback")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
                 cover: None,
                 image: None,
                 artist_name: None,
@@ -829,6 +841,8 @@ impl DirectHitItem {
                     name: None,
                     title: val.get("title").and_then(|v| v.as_str()).map(String::from),
                     picture: None,
+                    artwork_id: None,
+                    selected_album_cover_fallback: None,
                     cover: val.get("cover").and_then(|v| v.as_str()).map(String::from),
                     image: None,
                     artist_name,
@@ -864,6 +878,8 @@ impl DirectHitItem {
                     name: None,
                     title: val.get("title").and_then(|v| v.as_str()).map(String::from),
                     picture: None,
+                    artwork_id: None,
+                    selected_album_cover_fallback: None,
                     cover: None,
                     image: None,
                     artist_name,
@@ -899,6 +915,8 @@ impl DirectHitItem {
                     name: None,
                     title: val.get("title").and_then(|v| v.as_str()).map(String::from),
                     picture: None,
+                    artwork_id: None,
+                    selected_album_cover_fallback: None,
                     cover: None,
                     // Videos carry a thumbnail UUID under `imageId`, not album cover.
                     image: val
@@ -923,6 +941,8 @@ impl DirectHitItem {
                 name: None,
                 title: val.get("title").and_then(|v| v.as_str()).map(String::from),
                 picture: None,
+                artwork_id: None,
+                selected_album_cover_fallback: None,
                 cover: None,
                 image: val
                     .get("squareImage")
@@ -6093,6 +6113,27 @@ mod home_tab_tests {
         let bare_artist: TidalArtist = serde_json::from_str(&bare).expect("parses");
         assert_eq!(bare_artist.artwork_id, None);
         assert_eq!(bare_artist.selected_album_cover_fallback, None);
+    }
+
+    #[test]
+    fn direct_hit_artist_carries_artwork_fallback() {
+        let item = json!({
+            "type": "ARTISTS",
+            "value": {
+                "id": 7,
+                "name": "Jacoo",
+                "picture": null,
+                "artworkId": "art-9",
+                "selectedAlbumCoverFallback": "cover-9"
+            }
+        });
+        let hit = DirectHitItem::from_typed_value(&item).expect("artist hit parses");
+        assert_eq!(hit.picture, None);
+        assert_eq!(hit.artwork_id.as_deref(), Some("art-9"));
+        assert_eq!(
+            hit.selected_album_cover_fallback.as_deref(),
+            Some("cover-9")
+        );
     }
 }
 

--- a/src/components/ArtistPage.tsx
+++ b/src/components/ArtistPage.tsx
@@ -226,6 +226,11 @@ export default function ArtistPage({
       ? getTidalArtistImageUrl(s.uuid, hi ? 750 : 160)
       : getTidalImageUrl(s.uuid, hi ? 1280 : 320);
   const heroDisplay = showHi || showLow;
+  // Small avatars reuse the hero's resolved source — same URL, already cached,
+  // and already advanced past any source that failed to fetch.
+  const avatarSrc = heroSources[heroSrcIdx]
+    ? heroSrcUrl(heroSources[heroSrcIdx], false)
+    : "";
 
   // Restart resolution whenever the source set changes.
   useEffect(() => {
@@ -679,9 +684,9 @@ export default function ArtistPage({
             >
               <div className="flex items-center gap-3 px-6 pt-5 pb-4">
                 <div className="w-11 h-11 shrink-0 rounded-full overflow-hidden bg-th-surface-hover">
-                  {picture ? (
+                  {avatarSrc ? (
                     <img
-                      src={getTidalImageUrl(picture, 160)}
+                      src={avatarSrc}
                       alt={displayName}
                       className="w-full h-full object-cover"
                     />

--- a/src/components/ArtistPage.tsx
+++ b/src/components/ArtistPage.tsx
@@ -207,6 +207,7 @@ export default function ArtistPage({
 
   // Image sources in priority order: dedicated artist artwork → legacy picture →
   // album-cover fallbacks. Each loads progressively (small first, hi-res swaps in).
+  // Mirrors getArtistImage in src/utils/itemHelpers.ts — keep both in sync.
   const heroSources = useMemo(() => {
     const list: { uuid: string; kind: "artist" | "album" }[] = [];
     if (artworkId) list.push({ uuid: artworkId, kind: "artist" });
@@ -352,6 +353,8 @@ export default function ArtistPage({
           id: artistId,
           name: displayName,
           picture,
+          artworkId,
+          selectedAlbumCoverFallback: albumFallback,
         });
       }
     } catch (err) {

--- a/src/components/CardScrollSection.tsx
+++ b/src/components/CardScrollSection.tsx
@@ -143,6 +143,8 @@ export default function CardScrollSection({
                     id: item.id,
                     name: item.name,
                     picture: item.picture,
+                    artworkId: item.artworkId,
+                    selectedAlbumCoverFallback: item.selectedAlbumCoverFallback,
                   });
               };
             } else if (sectionType === "PLAYLIST_LIST" && item.uuid) {

--- a/src/components/HomeSection.tsx
+++ b/src/components/HomeSection.tsx
@@ -353,6 +353,8 @@ export default function HomeSection({ section }: HomeSectionProps) {
                     id: item.id,
                     name: item.name,
                     picture: item.picture,
+                    artworkId: item.artworkId,
+                    selectedAlbumCoverFallback: item.selectedAlbumCoverFallback,
                   });
                 }
               };

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -12,6 +12,7 @@ import {
   type Track,
   type MediaItemType,
 } from "../types";
+import { getArtistImage } from "../utils/itemHelpers";
 import TidalImage from "./TidalImage";
 import TrackContextMenu from "./TrackContextMenu";
 import MediaContextMenu from "./MediaContextMenu";
@@ -377,9 +378,9 @@ export default function SearchBar() {
                           }}
                         >
                           <div className="w-12 h-12 rounded-full bg-th-surface-hover overflow-hidden shrink-0">
-                            {hit.picture ? (
+                            {getArtistImage(hit, 160) ? (
                               <TidalImage
-                                src={getTidalImageUrl(hit.picture, 80)}
+                                src={getArtistImage(hit, 160)}
                                 alt={hit.name || ""}
                                 className="w-full h-full object-cover"
                               />

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -17,7 +17,11 @@ import {
   type DirectHitItem,
   type MediaItemType,
 } from "../types";
-import { videoToTrack, buildMediaItem } from "../utils/itemHelpers";
+import {
+  videoToTrack,
+  buildMediaItem,
+  getArtistImage,
+} from "../utils/itemHelpers";
 import TidalImage from "./TidalImage";
 import MediaContextMenu from "./MediaContextMenu";
 import TrackContextMenu from "./TrackContextMenu";
@@ -954,9 +958,9 @@ function TopHitsList({
               }}
             >
               <div className="w-12 h-12 rounded-full bg-th-surface-hover overflow-hidden shrink-0">
-                {hit.picture ? (
+                {getArtistImage(hit, 160) ? (
                   <TidalImage
-                    src={getTidalImageUrl(hit.picture, 80)}
+                    src={getArtistImage(hit, 160)}
                     alt={hit.name || ""}
                     className="w-full h-full object-cover"
                   />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -35,6 +35,7 @@ import {
   getTrackArtistDisplay,
   folderSubtitle,
   playlistCountLabel,
+  getArtistImage,
 } from "../utils/itemHelpers";
 import { useState, useCallback, useMemo, useRef, useEffect } from "react";
 import { useAtomValue, useAtom, useSetAtom } from "jotai";
@@ -805,9 +806,9 @@ export default function Sidebar() {
                         isCollapsed ? "w-10 h-10" : "w-10 h-10"
                       }`}
                     >
-                      {artist.picture ? (
+                      {getArtistImage(artist, 160) ? (
                         <TidalImage
-                          src={getTidalImageUrl(artist.picture, 80)}
+                          src={getArtistImage(artist, 160)}
                           alt={artist.name}
                           type="artist"
                         />

--- a/src/components/ViewAllPage.tsx
+++ b/src/components/ViewAllPage.tsx
@@ -231,6 +231,8 @@ export default function ViewAllPage({
               id: item.id,
               name: item.name,
               picture: item.picture,
+              artworkId: item.artworkId,
+              selectedAlbumCoverFallback: item.selectedAlbumCoverFallback,
             });
         },
       };

--- a/src/types.ts
+++ b/src/types.ts
@@ -299,6 +299,8 @@ export interface DirectHitItem {
   name?: string;
   title?: string;
   picture?: string;
+  artworkId?: string;
+  selectedAlbumCoverFallback?: string;
   cover?: string;
   image?: string;
   artistName?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -277,7 +277,13 @@ export type AppView =
     };
 
 export interface SearchResults {
-  artists: { id: number; name: string; picture?: string }[];
+  artists: {
+    id: number;
+    name: string;
+    picture?: string;
+    artworkId?: string;
+    selectedAlbumCoverFallback?: string;
+  }[];
   albums: AlbumDetail[];
   tracks: Track[];
   playlists: Playlist[];
@@ -557,6 +563,8 @@ export interface ArtistDetail {
   id: number;
   name: string;
   picture?: string;
+  artworkId?: string;
+  selectedAlbumCoverFallback?: string;
   handle?: string;
   userId?: number;
   popularity?: number;

--- a/src/utils/itemHelpers.test.ts
+++ b/src/utils/itemHelpers.test.ts
@@ -4,6 +4,8 @@ import {
   getAudioQualityBadge,
   getMediaQualityBadge,
   formatTotalDuration,
+  getArtistImage,
+  getItemImage,
 } from "./itemHelpers";
 
 describe("getTrackPrimaryArtist", () => {
@@ -134,5 +136,58 @@ describe("getMediaQualityBadge", () => {
 
   it("returns null when nothing is available", () => {
     expect(getMediaQualityBadge(undefined, undefined)).toBeNull();
+  });
+});
+
+describe("getArtistImage", () => {
+  it("prefers artworkId and uses artist CDN sizes", () => {
+    expect(
+      getArtistImage({ artworkId: "aaaa-bbbb", picture: "cccc-dddd" }, 480),
+    ).toBe("https://resources.tidal.com/images/aaaa/bbbb/480x480.jpg");
+  });
+
+  it("falls back to the legacy picture UUID", () => {
+    expect(getArtistImage({ picture: "cccc-dddd" }, 320)).toBe(
+      "https://resources.tidal.com/images/cccc/dddd/320x320.jpg",
+    );
+  });
+
+  it("uses selectedAlbumCoverFallback with album CDN sizes when no artist artwork exists", () => {
+    expect(
+      getArtistImage(
+        { picture: null, selectedAlbumCoverFallback: "eeee-ffff" },
+        640,
+      ),
+    ).toBe("https://resources.tidal.com/images/eeee/ffff/640x640.jpg");
+  });
+
+  it("accepts the camelCased albumCoverFallback alias used by ArtistPageData", () => {
+    expect(getArtistImage({ albumCoverFallback: "eeee-ffff" }, 320)).toBe(
+      "https://resources.tidal.com/images/eeee/ffff/320x320.jpg",
+    );
+  });
+
+  it("returns an empty string when the item has no image at all", () => {
+    expect(getArtistImage({ id: 1, name: "Nobody" })).toBe("");
+    expect(getArtistImage(null)).toBe("");
+  });
+});
+
+describe("getItemImage artist fallback", () => {
+  it("resolves an artist with no picture through the album fallback", () => {
+    expect(
+      getItemImage({
+        id: 1,
+        name: "CMA",
+        picture: null,
+        selectedAlbumCoverFallback: "eeee-ffff",
+      }),
+    ).toBe("https://resources.tidal.com/images/eeee/ffff/320x320.jpg");
+  });
+
+  it("still prefers an album cover for non-artist items", () => {
+    expect(getItemImage({ cover: "1111-2222", picture: "3333-4444" })).toBe(
+      "https://resources.tidal.com/images/1111/2222/320x320.jpg",
+    );
   });
 });

--- a/src/utils/itemHelpers.ts
+++ b/src/utils/itemHelpers.ts
@@ -1,5 +1,6 @@
 import {
   getTidalImageUrl,
+  getTidalArtistImageUrl,
   type MediaItemType,
   type StreamInfo,
   type Track,
@@ -44,6 +45,21 @@ export function formatStreamQuality(info: StreamInfo | null): string {
   }
   if (info.codec) parts.push(info.codec.toUpperCase());
   return parts.join(" ");
+}
+
+/**
+ * Artist avatar URL. Artist artwork and the legacy picture use the artist CDN
+ * size set; `selectedAlbumCoverFallback` is an album cover UUID and uses the
+ * album size set.
+ */
+export function getArtistImage(item: any, size: number = 320): string {
+  if (!item) return "";
+  const artistUuid = item.artworkId || item.picture;
+  if (artistUuid) return getTidalArtistImageUrl(artistUuid, size);
+  const albumFallback =
+    item.selectedAlbumCoverFallback || item.albumCoverFallback;
+  if (albumFallback) return getTidalImageUrl(albumFallback, size);
+  return "";
 }
 
 export function getItemImage(item: any, size: number = 320): string {
@@ -92,8 +108,9 @@ export function getItemImage(item: any, size: number = 320): string {
   if (item.cover) return getTidalImageUrl(item.cover, size);
   if (item.squareImage) return getTidalImageUrl(item.squareImage, size);
   if (item.image) return getTidalImageUrl(item.image, size);
-  // Artist picture UUID
-  if (item.picture) return getTidalImageUrl(item.picture, size);
+  // Artist artwork / picture / album-cover fallback
+  const artistImage = getArtistImage(item, size);
+  if (artistImage) return artistImage;
   // Nested album cover
   if (item.album?.cover) return getTidalImageUrl(item.album.cover, size);
   // V2 imageUrl direct

--- a/src/utils/itemHelpers.ts
+++ b/src/utils/itemHelpers.ts
@@ -51,6 +51,7 @@ export function formatStreamQuality(info: StreamInfo | null): string {
  * Artist avatar URL. Artist artwork and the legacy picture use the artist CDN
  * size set; `selectedAlbumCoverFallback` is an album cover UUID and uses the
  * album size set.
+ * ArtistPage.tsx repeats this priority chain for progressive loading — keep both in sync.
  */
 export function getArtistImage(item: any, size: number = 320): string {
   if (!item) return "";


### PR DESCRIPTION
## Problem

Artists with no photo rendered the person-silhouette placeholder everywhere, while the same artists show album artwork upstream — CMA, Electus, Killigrew and Jacoo were blank in "Your favorite artists"; only Jennifer Lopez, the one artist with a real photo, rendered.

Artist objects expose three image sources: `picture` (legacy photo UUID, `null` for many small artists), `artworkId` (newer dedicated artwork), and `selectedAlbumCoverFallback` (album cover substituted when the artist has no artwork). Two layers dropped the last two:

1. `getItemImage()` — the resolver behind every `MediaCard` — read only `item.picture`.
2. `TidalArtist`, `TidalArtistDetail` and `DirectHitItem` never declared the extra fields, so serde discarded them before the frontend saw them. Raw v2 feed items were unaffected; the typed paths (favorites, library, sidebar, search) were not.

`ArtistPage` already implemented the full chain for its hero, which is why the artist page looked right while its own cards did not.

Worth knowing for anything that touches this: artist UUIDs and album-cover UUIDs have different valid CDN sizes (160/320/480/750 vs 160/320/640/1280) — mixing the two builders silently 403s.

## Second problem: refreshed auth tokens were never persisted

`refresh_token` updated tokens in memory, but only `refresh_tidal_auth` wrote them back to settings. The automatic refresh after a 401 — the common path — never persisted, so the stored access token stayed stale and every launch burned a 401 before the first request succeeded.

## Testing

115/115 frontend (6 new), 93/93 Rust (2 new). Existing artist rendering is byte-identical: every call site requests 160 or 320, sizes both URL builders resolve the same way, so this is purely additive for artists that previously had no image.

## Not covered

`MixPage` seed-artist avatar — embedded artist refs carry only `picture` on the wire, so there is no fallback data to use there.
