### PR TITLE
Fix recently played row interactions

### DIFF
--- a/src/components/HomeSection.compactGrid.test.tsx
+++ b/src/components/HomeSection.compactGrid.test.tsx
@@ -72,6 +72,19 @@ const trackItem = {
   },
 };
 
+const otherTrackItem = {
+  _itemType: "TRACK",
+  id: 140680561,
+  title: "Highway Star",
+  duration: 367,
+  artists: [{ id: 3355, name: "Deep Purple", main: true }],
+  album: {
+    id: 140680537,
+    title: "Machine Head",
+    cover: "9b2f0c1a-1111-2222-3333-44445555aaaa",
+  },
+};
+
 const albumItem = {
   _itemType: "ALBUM",
   id: 111,
@@ -167,6 +180,31 @@ describe("Recently played — layout routing", () => {
     fireEvent.click(screen.getByText("Loved Tracks"));
     expect(navigateToFavorites).toHaveBeenCalled();
   });
+
+  // Neither the title match nor the mixed veto applies here, so this row must
+  // keep the original TrackListSection behavior.
+  const singleTypeTracks = {
+    ...makeSection("TRACK_LIST", [trackItem, otherTrackItem]),
+    title: "Suggested tracks",
+  };
+
+  it("plays from a single-type track row instead of navigating", () => {
+    renderSection(singleTypeTracks);
+    fireEvent.click(rowFor("Smoke On The Water"));
+    expect(playFromSource).toHaveBeenCalledTimes(1);
+    expect(playFromSource.mock.calls[0][0]).toBe(trackItem);
+    expect(navigateToAlbum).not.toHaveBeenCalled();
+  });
+
+  it("opens the album from a single-type track row's title", () => {
+    renderSection(singleTypeTracks);
+    fireEvent.click(screen.getByText("Highway Star"));
+    expect(navigateToAlbum).toHaveBeenCalledWith(140680537, {
+      title: "Machine Head",
+      cover: "9b2f0c1a-1111-2222-3333-44445555aaaa",
+    });
+    expect(playFromSource).not.toHaveBeenCalled();
+  });
 });
 
 describe("Recently played compact grid — navigation", () => {
@@ -220,7 +258,7 @@ describe("Recently played compact grid — play button", () => {
   afterEach(cleanup);
 
   const playButtonFor = (title: string) => {
-    const button = rowFor(title).querySelector('button[aria-label="Play"]');
+    const button = rowFor(title).querySelector('button[aria-label^="Play"]');
     if (!button) throw new Error(`no play button for ${title}`);
     return button;
   };
@@ -258,7 +296,7 @@ describe("Recently played compact grid — play button", () => {
   it("renders no play button for the Loved Tracks shortcut", () => {
     renderSection();
     expect(
-      rowFor("Loved Tracks").querySelector('button[aria-label="Play"]'),
+      rowFor("Loved Tracks").querySelector('button[aria-label^="Play"]'),
     ).toBeNull();
   });
 

--- a/src/components/HomeSection.compactGrid.test.tsx
+++ b/src/components/HomeSection.compactGrid.test.tsx
@@ -168,3 +168,49 @@ describe("Recently played — layout routing", () => {
     expect(navigateToFavorites).toHaveBeenCalled();
   });
 });
+
+describe("Recently played compact grid — navigation", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(cleanup);
+
+  it("opens the track's album page when the track row is clicked", () => {
+    renderSection();
+    fireEvent.click(rowFor("Smoke On The Water"));
+    expect(navigateToAlbum).toHaveBeenCalledWith(140680536, {
+      title: "Old But Gold 70's",
+      cover: "deb458e6-00d7-4b82-9650-82571008f785",
+    });
+    expect(playFromSource).not.toHaveBeenCalled();
+  });
+
+  it("opens the album page when the track title is clicked", () => {
+    renderSection();
+    fireEvent.click(screen.getByText("Smoke On The Water"));
+    expect(navigateToAlbum).toHaveBeenCalledWith(140680536, {
+      title: "Old But Gold 70's",
+      cover: "deb458e6-00d7-4b82-9650-82571008f785",
+    });
+    expect(playFromSource).not.toHaveBeenCalled();
+  });
+
+  it("opens the album page when an album row is clicked", () => {
+    renderSection();
+    fireEvent.click(rowFor("Machine Head"));
+    expect(navigateToAlbum).toHaveBeenCalledWith(111, expect.anything());
+  });
+
+  it("opens the playlist page when a playlist row is clicked", () => {
+    renderSection();
+    fireEvent.click(rowFor("Indie Hits"));
+    expect(navigateToPlaylist).toHaveBeenCalledWith(
+      "13f9d6c8-58e6-4869-8d9b-000d0ff95f0b",
+      expect.anything(),
+    );
+  });
+
+  it("opens favorites when the Loved Tracks shortcut is clicked", () => {
+    renderSection();
+    fireEvent.click(rowFor("Loved Tracks"));
+    expect(navigateToFavorites).toHaveBeenCalled();
+  });
+});

--- a/src/components/HomeSection.compactGrid.test.tsx
+++ b/src/components/HomeSection.compactGrid.test.tsx
@@ -214,3 +214,66 @@ describe("Recently played compact grid — navigation", () => {
     expect(navigateToFavorites).toHaveBeenCalled();
   });
 });
+
+describe("Recently played compact grid — play button", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(cleanup);
+
+  const playButtonFor = (title: string) => {
+    const button = rowFor(title).querySelector('button[aria-label="Play"]');
+    if (!button) throw new Error(`no play button for ${title}`);
+    return button;
+  };
+
+  it("plays the track without navigating", () => {
+    renderSection();
+    fireEvent.click(playButtonFor("Smoke On The Water"));
+    expect(playFromSource).toHaveBeenCalledTimes(1);
+    expect(playFromSource.mock.calls[0][0]).toBe(trackItem);
+    expect(playFromSource.mock.calls[0][1]).toEqual([trackItem]);
+    expect(navigateToAlbum).not.toHaveBeenCalled();
+  });
+
+  it("plays the album without navigating", () => {
+    renderSection();
+    fireEvent.click(playButtonFor("Machine Head"));
+    expect(playMedia).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "album", id: 111 }),
+    );
+    expect(navigateToAlbum).not.toHaveBeenCalled();
+  });
+
+  it("plays the playlist without navigating", () => {
+    renderSection();
+    fireEvent.click(playButtonFor("Indie Hits"));
+    expect(playMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "playlist",
+        uuid: "13f9d6c8-58e6-4869-8d9b-000d0ff95f0b",
+      }),
+    );
+    expect(navigateToPlaylist).not.toHaveBeenCalled();
+  });
+
+  it("renders no play button for the Loved Tracks shortcut", () => {
+    renderSection();
+    expect(
+      rowFor("Loved Tracks").querySelector('button[aria-label="Play"]'),
+    ).toBeNull();
+  });
+
+  it("plays albums from a track-first row too", () => {
+    renderSection(
+      makeSection("TRACK_LIST", [
+        trackItem,
+        albumItem,
+        playlistItem,
+        myTracksItem,
+      ]),
+    );
+    fireEvent.click(playButtonFor("Machine Head"));
+    expect(playMedia).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "album", id: 111 }),
+    );
+  });
+});

--- a/src/components/HomeSection.compactGrid.test.tsx
+++ b/src/components/HomeSection.compactGrid.test.tsx
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { Provider, createStore } from "jotai";
+import type { PropsWithChildren } from "react";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(() => Promise.resolve(undefined)),
+}));
+
+const navigateToAlbum = vi.fn();
+const navigateToPlaylist = vi.fn();
+const navigateToFavorites = vi.fn();
+const navigateToViewAll = vi.fn();
+const navigateToArtist = vi.fn();
+const navigateToMix = vi.fn();
+
+vi.mock("../hooks/useNavigation", () => ({
+  useNavigation: () => ({
+    navigateToAlbum,
+    navigateToPlaylist,
+    navigateToFavorites,
+    navigateToViewAll,
+    navigateToArtist,
+    navigateToMix,
+  }),
+}));
+
+const playFromSource = vi.fn();
+vi.mock("../hooks/usePlaybackActions", () => ({
+  usePlaybackActions: () => ({ playFromSource }),
+}));
+
+const playMedia = vi.fn();
+vi.mock("../hooks/useMediaPlay", () => ({
+  useMediaPlay: () => playMedia,
+}));
+
+vi.mock("../hooks/useFavorites", () => ({
+  useFavorites: () => ({
+    favoriteVideoIds: new Set(),
+    addFavoriteVideo: vi.fn(),
+    removeFavoriteVideo: vi.fn(),
+    favoriteAlbumIds: new Set(),
+    addFavoriteAlbum: vi.fn(),
+    removeFavoriteAlbum: vi.fn(),
+    favoritePlaylistUuids: new Set(),
+    addFavoritePlaylist: vi.fn(),
+    removeFavoritePlaylist: vi.fn(),
+    followedArtistIds: new Set(),
+    followArtist: vi.fn(),
+    unfollowArtist: vi.fn(),
+    favoriteMixIds: new Set(),
+    addFavoriteMix: vi.fn(),
+    removeFavoriteMix: vi.fn(),
+  }),
+}));
+
+import HomeSection from "./HomeSection";
+
+// Shapes copied from a real v2 home feed "Recently played" section
+// (moduleId CONTINUE_LISTEN_TO): items arrive unwrapped, carrying _itemType.
+const trackItem = {
+  _itemType: "TRACK",
+  id: 140680560,
+  title: "Smoke On The Water",
+  duration: 228,
+  artists: [{ id: 3355, name: "Deep Purple", main: true }],
+  album: {
+    id: 140680536,
+    title: "Old But Gold 70's",
+    cover: "deb458e6-00d7-4b82-9650-82571008f785",
+  },
+};
+
+const albumItem = {
+  _itemType: "ALBUM",
+  id: 111,
+  title: "Machine Head",
+  cover: "aaaa-bbbb",
+  artists: [{ id: 3355, name: "Deep Purple" }],
+  numberOfTracks: 7,
+};
+
+const playlistItem = {
+  _itemType: "PLAYLIST",
+  uuid: "13f9d6c8-58e6-4869-8d9b-000d0ff95f0b",
+  title: "Indie Hits",
+  squareImage: "e1cf1fae-5763-46e1-a0d7-651b2af21d00",
+  creator: { id: 0, type: "TIDAL" },
+  numberOfTracks: 51,
+};
+
+const myTracksItem = {
+  _itemType: "DEEP_LINK",
+  title: "My Tracks",
+  id: "tidal://my-collection/tracks",
+  url: "tidal://my-collection/tracks",
+};
+
+// The backend types the row from its FIRST item, so the same row arrives as
+// ALBUM_LIST or TRACK_LIST depending on what was played last.
+function makeSection(sectionType: string, items: unknown[]) {
+  return {
+    title: "Recently played",
+    sectionType,
+    items,
+    hasMore: true,
+    apiPath: "home/pages/CONTINUE_LISTEN_TO/view-all",
+  };
+}
+
+function renderSection(
+  section: ReturnType<typeof makeSection> = makeSection("ALBUM_LIST", [
+    albumItem,
+    trackItem,
+    playlistItem,
+    myTracksItem,
+  ]),
+) {
+  const store = createStore();
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <Provider store={store}>{children}</Provider>
+  );
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return render(<HomeSection section={section as any} />, { wrapper });
+}
+
+function rowFor(title: string): HTMLElement {
+  const row = screen.getByText(title).closest("div.group");
+  if (!row) throw new Error(`no row for ${title}`);
+  return row as HTMLElement;
+}
+
+describe("Recently played — layout routing", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(cleanup);
+
+  // The row is typed TRACK_LIST whenever a track was played most recently.
+  // It must still render as the compact grid, or album rows get handed to
+  // playFromSource as if they were tracks.
+  const trackFirst = makeSection("TRACK_LIST", [
+    trackItem,
+    albumItem,
+    playlistItem,
+    myTracksItem,
+  ]);
+
+  it("opens the album page when a track-first row's album is clicked", () => {
+    renderSection(trackFirst);
+    fireEvent.click(rowFor("Machine Head"));
+    expect(navigateToAlbum).toHaveBeenCalledWith(111, expect.anything());
+    expect(playFromSource).not.toHaveBeenCalled();
+  });
+
+  it("opens the playlist page when a track-first row's playlist is clicked", () => {
+    renderSection(trackFirst);
+    fireEvent.click(rowFor("Indie Hits"));
+    expect(navigateToPlaylist).toHaveBeenCalledWith(
+      "13f9d6c8-58e6-4869-8d9b-000d0ff95f0b",
+      expect.anything(),
+    );
+    expect(playFromSource).not.toHaveBeenCalled();
+  });
+
+  it("shows the Loved Tracks shortcut in a track-first row", () => {
+    renderSection(trackFirst);
+    fireEvent.click(screen.getByText("Loved Tracks"));
+    expect(navigateToFavorites).toHaveBeenCalled();
+  });
+});

--- a/src/components/HomeSection.tsx
+++ b/src/components/HomeSection.tsx
@@ -762,6 +762,8 @@ function CompactGridSection({
         {displayItems.map((item: any, idx: number) => {
           const isTrack = isTrackItem(item, typeHint);
           const myTracks = isMyTracksItem(item);
+          // Deep links and artifact-less promo cards have nothing to play.
+          const canPlay = isTrack || buildMediaItem(item, typeHint) !== null;
           return (
             <div
               key={getItemId(item)}
@@ -788,9 +790,9 @@ function CompactGridSection({
                     <Music size={16} className="text-th-text-faint" />
                   </div>
                 )}
-                {!myTracks && (
+                {canPlay && (
                   <button
-                    aria-label="Play"
+                    aria-label={`Play ${getItemTitle(item)}`}
                     onClick={(e) => handlePlay(e, item)}
                     className="absolute inset-0 bg-black/40 flex items-center justify-center opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity cursor-pointer"
                   >
@@ -807,16 +809,7 @@ function CompactGridSection({
                   {myTracks ? (
                     "Loved Tracks"
                   ) : isTrack && item.album ? (
-                    <span
-                      className="hover:underline"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        navigateToAlbum(item.album.id, {
-                          title: item.album.title,
-                          cover: item.album.cover,
-                        });
-                      }}
-                    >
+                    <span className="hover:underline">
                       {getItemTitle(item)}
                     </span>
                   ) : (

--- a/src/components/HomeSection.tsx
+++ b/src/components/HomeSection.tsx
@@ -636,6 +636,8 @@ function CompactGridSection({
   onItemClick: (item: any) => void;
 }) {
   const { navigateToViewAll, navigateToAlbum } = useNavigation();
+  const { playFromSource } = usePlaybackActions();
+  const playMedia = useMediaPlay();
   const displayItems = items.slice(0, 16);
 
   // Track context menu (for track items)
@@ -722,6 +724,25 @@ function CompactGridSection({
     onItemClick(item);
   };
 
+  const trackItems = displayItems.filter((t: any) => isTrackItem(t, typeHint));
+
+  const handlePlay = (e: React.MouseEvent, item: any) => {
+    e.stopPropagation();
+    if (isTrackItem(item, typeHint)) {
+      playFromSource(item, trackItems, {
+        source: {
+          type: "home-section",
+          id: section.title,
+          name: section.title,
+          allTracks: trackItems,
+        },
+      });
+      return;
+    }
+    const mediaItem = buildMediaItem(item, typeHint);
+    if (mediaItem) playMedia(mediaItem);
+  };
+
   return (
     <section className="mb-8">
       <div className="flex items-center justify-between mb-4">
@@ -768,13 +789,17 @@ function CompactGridSection({
                   </div>
                 )}
                 {!myTracks && (
-                  <div className="absolute inset-0 bg-black/40 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
+                  <button
+                    aria-label="Play"
+                    onClick={(e) => handlePlay(e, item)}
+                    className="absolute inset-0 bg-black/40 flex items-center justify-center opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity cursor-pointer"
+                  >
                     <Play
                       size={14}
                       fill="white"
                       className="text-white ml-0.5"
                     />
-                  </div>
+                  </button>
                 )}
               </div>
               <div className="flex-1 min-w-0">

--- a/src/components/HomeSection.tsx
+++ b/src/components/HomeSection.tsx
@@ -24,6 +24,7 @@ import {
   getItemTitle,
   getItemSubtitle,
   getItemId,
+  getItemType,
   isArtistItem,
   isTrackItem,
   isMixItem,
@@ -76,9 +77,16 @@ export default function HomeSection({ section }: HomeSectionProps) {
     position: { x: number; y: number };
   } | null>(null);
 
+  const items = Array.isArray(section.items) ? section.items : [];
+  // The backend types a row from its first item, so a mixed row can arrive as
+  // TRACK_LIST. Its section type is then a lie about every following item.
+  const isMixedSection =
+    new Set(items.map((i) => getItemType(i)).filter(Boolean)).size > 1;
+  const typeHint = isMixedSection ? undefined : section.sectionType;
+
   const handleContextMenu = useCallback(
     (e: React.MouseEvent, item: any) => {
-      const mediaItem = buildMediaItem(item, section.sectionType);
+      const mediaItem = buildMediaItem(item, typeHint);
       if (mediaItem) {
         e.preventDefault();
         e.stopPropagation();
@@ -88,10 +96,9 @@ export default function HomeSection({ section }: HomeSectionProps) {
         });
       }
     },
-    [section.sectionType],
+    [typeHint],
   );
 
-  const items = Array.isArray(section.items) ? section.items : [];
   if (items.length === 0) return null;
 
   const handleScroll = () => {
@@ -153,15 +160,13 @@ export default function HomeSection({ section }: HomeSectionProps) {
           return;
       }
     }
-    const asMedia = buildMediaItem(item, section.sectionType);
+    const asMedia = buildMediaItem(item, typeHint);
     if (asMedia?.type === "video") {
       playMedia(asMedia);
       return;
     }
-    if (isTrackItem(item, section.sectionType)) {
-      const allTrackItems = items.filter((t: any) =>
-        isTrackItem(t, section.sectionType),
-      );
+    if (isTrackItem(item, typeHint)) {
+      const allTrackItems = items.filter((t: any) => isTrackItem(t, typeHint));
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       playFromSource(item as any, allTrackItems as any, {
         source: {
@@ -171,7 +176,7 @@ export default function HomeSection({ section }: HomeSectionProps) {
           allTracks: allTrackItems as any,
         },
       });
-    } else if (isMixItem(item, section.sectionType)) {
+    } else if (isMixItem(item, typeHint)) {
       // Mix or radio station - navigate to mix page
       const mixId = item.mixId || item.id?.toString();
       if (mixId) {
@@ -182,7 +187,7 @@ export default function HomeSection({ section }: HomeSectionProps) {
           mixType: item.type || item.mixType,
         });
       }
-    } else if (isArtistItem(item, section.sectionType)) {
+    } else if (isArtistItem(item, typeHint)) {
       // Artist - navigate to artist page
       const artistId = item.id;
       if (artistId) {
@@ -211,10 +216,13 @@ export default function HomeSection({ section }: HomeSectionProps) {
     }
   };
 
-  const isTrackSection = section.sectionType === "TRACK_LIST";
   const isCompactGrid =
     section.sectionType === "COMPACT_GRID_CARD" ||
     section.title === "Recently played";
+  // Rendering a mixed row as a track list hands albums and playlists to
+  // playFromSource, which cannot play them.
+  const isTrackSection =
+    section.sectionType === "TRACK_LIST" && !isCompactGrid && !isMixedSection;
   const isMultiPromo = section.sectionType === "MULTIPLE_TOP_PROMOTIONS";
 
   if (isTrackSection) {
@@ -226,6 +234,7 @@ export default function HomeSection({ section }: HomeSectionProps) {
       <CompactGridSection
         section={section}
         items={items}
+        typeHint={typeHint}
         onItemClick={handleItemClick}
       />
     );
@@ -305,11 +314,10 @@ export default function HomeSection({ section }: HomeSectionProps) {
                 />
               );
             }
-            const isVideo =
-              buildMediaItem(item, section.sectionType)?.type === "video";
-            const isArtist = isArtistItem(item, section.sectionType);
-            const isMix = isMixItem(item, section.sectionType);
-            const isTrack = isTrackItem(item, section.sectionType);
+            const isVideo = buildMediaItem(item, typeHint)?.type === "video";
+            const isArtist = isArtistItem(item, typeHint);
+            const isMix = isMixItem(item, typeHint);
+            const isTrack = isTrackItem(item, typeHint);
             const isPlaylist = !isArtist && !isMix && !isTrack && !!item.uuid;
             const isAlbum =
               !isVideo &&
@@ -392,7 +400,7 @@ export default function HomeSection({ section }: HomeSectionProps) {
               }
             }
 
-            const mediaItem = buildMediaItem(item, section.sectionType);
+            const mediaItem = buildMediaItem(item, typeHint);
             const myTracks = isMyTracksItem(item);
 
             return (
@@ -619,10 +627,12 @@ function TrackListSection({
 function CompactGridSection({
   section,
   items,
+  typeHint,
   onItemClick,
 }: {
   section: HomeSectionType;
   items: any[];
+  typeHint?: string;
   onItemClick: (item: any) => void;
 }) {
   const { navigateToViewAll, navigateToAlbum } = useNavigation();
@@ -647,14 +657,14 @@ function CompactGridSection({
       e.stopPropagation();
       const position = { x: e.clientX, y: e.clientY };
 
-      if (isTrackItem(item, section.sectionType)) {
+      if (isTrackItem(item, typeHint)) {
         setTrackContextMenu({ track: item, index, position });
         return;
       }
 
       // Build MediaItemType for non-track items
       let mediaItem: MediaItemType | null = null;
-      if (isMixItem(item, section.sectionType)) {
+      if (isMixItem(item, typeHint)) {
         const mixId = item.mixId || item.id?.toString();
         if (mixId) {
           mediaItem = {
@@ -665,7 +675,7 @@ function CompactGridSection({
             subtitle: getItemSubtitle(item),
           };
         }
-      } else if (isArtistItem(item, section.sectionType)) {
+      } else if (isArtistItem(item, typeHint)) {
         if (item.id) {
           mediaItem = {
             type: "artist",
@@ -698,7 +708,7 @@ function CompactGridSection({
         setMediaContextMenu({ item: mediaItem, position });
       }
     },
-    [section.sectionType],
+    [typeHint],
   );
 
   return (
@@ -718,7 +728,7 @@ function CompactGridSection({
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-x-6 gap-y-1">
         {displayItems.map((item: any, idx: number) => {
-          const isTrack = isTrackItem(item, section.sectionType);
+          const isTrack = isTrackItem(item, typeHint);
           const myTracks = isMyTracksItem(item);
           return (
             <div

--- a/src/components/HomeSection.tsx
+++ b/src/components/HomeSection.tsx
@@ -711,6 +711,17 @@ function CompactGridSection({
     [typeHint],
   );
 
+  const handleRowClick = (item: any) => {
+    if (isTrackItem(item, typeHint) && item.album?.id) {
+      navigateToAlbum(item.album.id, {
+        title: item.album.title,
+        cover: item.album.cover,
+      });
+      return;
+    }
+    onItemClick(item);
+  };
+
   return (
     <section className="mb-8">
       <div className="flex items-center justify-between mb-4">
@@ -733,7 +744,7 @@ function CompactGridSection({
           return (
             <div
               key={getItemId(item)}
-              onClick={() => onItemClick(item)}
+              onClick={() => handleRowClick(item)}
               onContextMenu={
                 myTracks ? undefined : (e) => openMenu(e, item, idx)
               }

--- a/src/components/ViewAllPage.lovedTracks.test.tsx
+++ b/src/components/ViewAllPage.lovedTracks.test.tsx
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { Provider, createStore } from "jotai";
+import type { PropsWithChildren } from "react";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(() => Promise.resolve(undefined)),
+}));
+
+const navigateToAlbum = vi.fn();
+const navigateToPlaylist = vi.fn();
+const navigateToArtist = vi.fn();
+const navigateToMix = vi.fn();
+const navigateToFavorites = vi.fn();
+
+vi.mock("../hooks/useNavigation", () => ({
+  useNavigation: () => ({
+    navigateToAlbum,
+    navigateToPlaylist,
+    navigateToArtist,
+    navigateToMix,
+    navigateToFavorites,
+  }),
+}));
+
+const playFromSource = vi.fn();
+vi.mock("../hooks/usePlaybackActions", () => ({
+  usePlaybackActions: () => ({ playFromSource }),
+}));
+
+const playMedia = vi.fn();
+vi.mock("../hooks/useMediaPlay", () => ({
+  useMediaPlay: () => playMedia,
+}));
+
+vi.mock("../hooks/useFavorites", () => ({
+  useFavorites: () => ({
+    favoriteVideoIds: new Set(),
+    addFavoriteVideo: vi.fn(),
+    removeFavoriteVideo: vi.fn(),
+    favoriteAlbumIds: new Set(),
+    addFavoriteAlbum: vi.fn(),
+    removeFavoriteAlbum: vi.fn(),
+    followedArtistIds: new Set(),
+    followArtist: vi.fn(),
+    unfollowArtist: vi.fn(),
+    favoritePlaylistUuids: new Set(),
+    addFavoritePlaylist: vi.fn(),
+    removeFavoritePlaylist: vi.fn(),
+    favoriteMixIds: new Set(),
+    addFavoriteMix: vi.fn(),
+    removeFavoriteMix: vi.fn(),
+  }),
+}));
+
+const myTracksItem = {
+  _itemType: "DEEP_LINK",
+  title: "My Tracks",
+  id: "tidal://my-collection/tracks",
+  url: "tidal://my-collection/tracks",
+};
+
+const albumItem = {
+  _itemType: "ALBUM",
+  id: 111,
+  title: "Machine Head",
+  cover: "aaaa-bbbb",
+  artists: [{ id: 3355, name: "Deep Purple" }],
+};
+
+// Spread the real module: ViewAllPage's transitive imports (MediaContextMenu →
+// fetchMediaTracks, AddToPlaylistMenu → getAllPlaylists, …) resolve lazily, so
+// a partial mock would only explode once one of them is exercised.
+// The fixtures above are read at call time inside the mocked fn, not during
+// factory evaluation — do not inline them as the factory's return value.
+vi.mock("../api/tidal", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../api/tidal")>()),
+  getPageSection: vi.fn(() =>
+    Promise.resolve({
+      sections: [
+        { title: "Recently played", items: [albumItem, myTracksItem] },
+      ],
+    }),
+  ),
+  getArtistViewAll: vi.fn(() => Promise.resolve({ items: [], hasMore: false })),
+}));
+
+import ViewAllPage from "./ViewAllPage";
+
+function renderPage() {
+  const store = createStore();
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <Provider store={store}>{children}</Provider>
+  );
+  return render(
+    <ViewAllPage
+      title="Recently played"
+      apiPath="home/pages/CONTINUE_LISTEN_TO/view-all"
+      onBack={() => {}}
+    />,
+    { wrapper },
+  );
+}
+
+describe("ViewAllPage — Loved Tracks shortcut", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(cleanup);
+
+  it("labels the deep-link card 'Loved Tracks'", async () => {
+    renderPage();
+    await waitFor(() => screen.getByText("Loved Tracks"));
+  });
+
+  it("navigates to favorites instead of an album", async () => {
+    renderPage();
+    await waitFor(() => screen.getByText("Loved Tracks"));
+    fireEvent.click(screen.getByText("Loved Tracks"));
+    expect(navigateToFavorites).toHaveBeenCalled();
+    expect(navigateToAlbum).not.toHaveBeenCalled();
+  });
+
+  it("renders no play button on the Loved Tracks card", async () => {
+    renderPage();
+    await waitFor(() => screen.getByText("Loved Tracks"));
+    const card = screen.getByText("Loved Tracks").closest("div.group");
+    expect(card?.querySelector("button")).toBeNull();
+  });
+
+  it("still routes normal album cards to the album page", async () => {
+    renderPage();
+    await waitFor(() => screen.getByText("Machine Head"));
+    fireEvent.click(screen.getByText("Machine Head"));
+    expect(navigateToAlbum).toHaveBeenCalledWith(111, expect.anything());
+  });
+});

--- a/src/components/ViewAllPage.tsx
+++ b/src/components/ViewAllPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
+import { Heart } from "lucide-react";
 import { usePlaybackActions } from "../hooks/usePlaybackActions";
 import { useMediaPlay } from "../hooks/useMediaPlay";
 import { useNavigation } from "../hooks/useNavigation";
@@ -23,6 +24,7 @@ import {
   isArtistItem,
   isTrackItem,
   isMixItem,
+  isMyTracksItem,
   buildMediaItem,
 } from "../utils/itemHelpers";
 
@@ -47,6 +49,7 @@ export default function ViewAllPage({
     navigateToPlaylist,
     navigateToArtist,
     navigateToMix,
+    navigateToFavorites,
   } = useNavigation();
   const {
     favoriteVideoIds,
@@ -158,6 +161,10 @@ export default function ViewAllPage({
   }, [artistId, hasMore, handleLoadMore]);
 
   const handleItemClick = (item: any) => {
+    if (isMyTracksItem(item)) {
+      navigateToFavorites();
+      return;
+    }
     const mediaItem = buildMediaItem(item);
     if (mediaItem?.type === "video") {
       playMedia(mediaItem);
@@ -210,6 +217,9 @@ export default function ViewAllPage({
   const hasMixes = items.length > 0 && items.every((item) => isMixItem(item));
 
   const getFavoriteProps = (item: any) => {
+    // A deep link has no favorite state; its string id would otherwise reach
+    // the album-favorite branch below.
+    if (isMyTracksItem(item)) return {};
     if (buildMediaItem(item)?.type === "video" && item.id) {
       return {
         isFavorited: favoriteVideoIds.has(item.id),
@@ -295,12 +305,15 @@ export default function ViewAllPage({
             {items.map((item: any) => {
               const favProps = getFavoriteProps(item);
               const mediaItem = buildMediaItem(item);
+              const myTracks = isMyTracksItem(item);
               return (
                 <MediaCard
                   key={getItemId(item)}
                   item={item}
                   onClick={() => handleItemClick(item)}
-                  onContextMenu={(e) => handleContextMenu(e, item)}
+                  onContextMenu={
+                    myTracks ? undefined : (e) => handleContextMenu(e, item)
+                  }
                   onPlay={
                     !hasArtists && !hasMixes && mediaItem
                       ? (e) => {
@@ -310,9 +323,18 @@ export default function ViewAllPage({
                       : undefined
                   }
                   isArtist={isArtistItem(item) || hasArtists}
-                  showPlayButton={!hasArtists && !hasMixes}
+                  showPlayButton={!myTracks && !hasArtists && !hasMixes}
                   isFavorited={favProps.isFavorited}
                   onFavoriteToggle={favProps.onFavoriteToggle}
+                  {...(myTracks && {
+                    titleOverride: "Loved Tracks",
+                    subtitleOverride: "Collection",
+                    imageOverride: (
+                      <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-[#450af5] via-[#8e2de2] to-[#00d2ff]">
+                        <Heart size={40} className="text-white" fill="white" />
+                      </div>
+                    ),
+                  })}
                 />
               );
             })}

--- a/src/utils/itemHelpers.test.ts
+++ b/src/utils/itemHelpers.test.ts
@@ -6,6 +6,9 @@ import {
   formatTotalDuration,
   getArtistImage,
   getItemImage,
+  getItemTitle,
+  getItemId,
+  buildMediaItem,
 } from "./itemHelpers";
 
 describe("getTrackPrimaryArtist", () => {
@@ -189,5 +192,51 @@ describe("getItemImage artist fallback", () => {
     expect(getItemImage({ cover: "1111-2222", picture: "3333-4444" })).toBe(
       "https://resources.tidal.com/images/1111/2222/320x320.jpg",
     );
+  });
+});
+
+describe("deep-link items (v2 My Tracks shortcut)", () => {
+  // The backend unwraps {type, data} and injects _itemType, so the runtime
+  // item is flat. The wrapped shape still arrives from v1 payloads.
+  const unwrapped = {
+    _itemType: "DEEP_LINK",
+    title: "My Tracks",
+    id: "tidal://my-collection/tracks",
+    url: "tidal://my-collection/tracks",
+    externalUrl: false,
+  };
+  const wrapped = {
+    type: "DEEP_LINK",
+    data: {
+      title: "My Tracks",
+      id: "tidal://my-collection/tracks",
+      url: "tidal://my-collection/tracks",
+    },
+  };
+
+  it("reads the title from an unwrapped deep link", () => {
+    expect(getItemTitle(unwrapped)).toBe("My Tracks");
+  });
+
+  it("still reads the title from a wrapped deep link", () => {
+    expect(getItemTitle(wrapped)).toBe("My Tracks");
+  });
+
+  it("returns a stable id for an unwrapped deep link", () => {
+    expect(getItemId(unwrapped)).toBe("tidal://my-collection/tracks");
+  });
+
+  it("returns a stable id for a wrapped deep link", () => {
+    expect(getItemId(wrapped)).toBe("tidal://my-collection/tracks");
+  });
+
+  it("has no image for either shape", () => {
+    expect(getItemImage(unwrapped)).toBe("");
+    expect(getItemImage(wrapped)).toBe("");
+  });
+
+  it("is not playable media", () => {
+    expect(buildMediaItem(unwrapped)).toBeNull();
+    expect(buildMediaItem(wrapped)).toBeNull();
   });
 });

--- a/src/utils/itemHelpers.ts
+++ b/src/utils/itemHelpers.ts
@@ -131,7 +131,7 @@ export function getItemTitle(item: any): string {
     return item.data?.shortHeader ?? "";
   }
   if (isDeepLinkItem(item)) {
-    return item.data?.title ?? "";
+    return item.data?.title ?? item.title ?? "";
   }
   if (item.title) return item.title;
   if (item.name) return item.name;
@@ -186,7 +186,7 @@ export function getItemId(item: any): string {
     return item.data?.artifactId ?? String(item.data?.id ?? "");
   }
   if (isDeepLinkItem(item)) {
-    return String(item.data?.id ?? item.data?.url ?? "");
+    return String(item.data?.id ?? item.data?.url ?? item.id ?? item.url ?? "");
   }
   return (
     item.id?.toString() ||
@@ -272,6 +272,8 @@ export function buildMediaItem(
   item: any,
   sectionType?: string,
 ): MediaItemType | null {
+  // A deep link is a navigation target, not media.
+  if (isDeepLinkItem(item)) return null;
   // MAGAZINE promo card wraps a playlist artifact.
   if (isMagazineItem(item)) {
     const d = item.data;


### PR DESCRIPTION
## Bugs

- Clicking a track in Recently played started playing it instead of opening its album.
- Clicking a track's name did nothing useful.
- Hovering a row showed a play button that did nothing — no track, album, or playlist would start.
- On the Recently played "View all" page, the Loved Tracks entry showed up blank and led nowhere.
