### PR TITLE
fix(ui): stop the window resize strip from swallowing the content scrollbar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -65,10 +65,13 @@ textarea {
   width: 100%;
 }
 
-/* Custom Scrollbar - Thinner and Darker */
+/* Track is wider than the thumb on purpose: the transparent border keeps the
+   thumb 6px while the draggable band is 10px, so the window edge-resize strip
+   can't swallow the whole scrollbar. Set background-color, never the
+   `background` shorthand — the shorthand resets background-clip. */
 ::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
+  width: 10px;
+  height: 10px;
 }
 
 ::-webkit-scrollbar-track {
@@ -76,12 +79,14 @@ textarea {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--th-scrollbar, #333);
-  border-radius: 3px;
+  background-color: var(--th-scrollbar, #333);
+  background-clip: content-box;
+  border: 2px solid transparent;
+  border-radius: 5px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: var(--th-scrollbar-hover, #555);
+  background-color: var(--th-scrollbar-hover, #555);
 }
 
 /* Hide scrollbar for specific elements but keep functionality */
@@ -93,15 +98,16 @@ textarea {
   scrollbar-width: none; /* Firefox */
 }
 
-/* Custom utility for the sidebar scrollbar to match Tidal's subtle look */
+/* Subtler variant: 3px border leaves a 4px thumb in the same 10px band. */
 .custom-scrollbar::-webkit-scrollbar {
-  width: 4px;
+  width: 10px;
 }
 .custom-scrollbar::-webkit-scrollbar-thumb {
-  background: var(--th-scrollbar, #222);
+  background-color: var(--th-scrollbar, #222);
+  border: 3px solid transparent;
 }
 .custom-scrollbar:hover::-webkit-scrollbar-thumb {
-  background: var(--th-scrollbar-hover, #444);
+  background-color: var(--th-scrollbar-hover, #444);
 }
 
 /* Player bar - prevent text selection during scrubbing */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,7 +80,7 @@ function AppChrome({ children }: { children: ReactNode }) {
     <div className="relative flex flex-col h-full w-full overflow-hidden">
       {!nativeChrome && !hideTitleBar && <TitleBar />}
       <div className="flex-1 min-h-0 overflow-hidden">{children}</div>
-      {!nativeChrome && <ResizeEdges top={4} bottom={4} left={4} right={4} />}
+      {!nativeChrome && <ResizeEdges top={4} bottom={4} left={4} right={2} />}
     </div>
   );
 }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -125,7 +125,7 @@ export default function Layout({ children }: LayoutProps) {
         <PlayerBar />
       </div>
       {currentVideo && <VideoPlayer />}
-      {!nativeChrome && <ResizeEdges top={4} bottom={4} left={4} right={4} />}
+      {!nativeChrome && <ResizeEdges top={4} bottom={4} left={4} right={2} />}
     </div>
   );
 }

--- a/src/components/ResizeEdges.test.tsx
+++ b/src/components/ResizeEdges.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, cleanup, waitFor, act } from "@testing-library/react";
+
+const { isMaximized, isFullscreen, onResized, startResizeDragging } =
+  vi.hoisted(() => ({
+    isMaximized: vi.fn(),
+    isFullscreen: vi.fn(),
+    onResized: vi.fn(),
+    startResizeDragging: vi.fn(),
+  }));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    isMaximized,
+    isFullscreen,
+    onResized,
+    startResizeDragging,
+  }),
+}));
+
+import ResizeEdges from "./ResizeEdges";
+
+let resizeHandler: (() => void) | null = null;
+
+function setWindowState({
+  maximized,
+  fullscreen,
+}: {
+  maximized: boolean;
+  fullscreen: boolean;
+}) {
+  isMaximized.mockResolvedValue(maximized);
+  isFullscreen.mockResolvedValue(fullscreen);
+}
+
+describe("ResizeEdges", () => {
+  beforeEach(() => {
+    cleanup();
+    isMaximized.mockReset();
+    isFullscreen.mockReset();
+    startResizeDragging.mockReset();
+    resizeHandler = null;
+    onResized.mockReset();
+    onResized.mockImplementation((handler: () => void) => {
+      resizeHandler = handler;
+      return Promise.resolve(() => {});
+    });
+  });
+
+  it("renders all eight grab zones while windowed", async () => {
+    setWindowState({ maximized: false, fullscreen: false });
+    const { container } = render(<ResizeEdges />);
+    await waitFor(() =>
+      expect(container.querySelectorAll("[data-resize-edge]")).toHaveLength(8),
+    );
+  });
+
+  it("sizes the east zone from the right prop", async () => {
+    setWindowState({ maximized: false, fullscreen: false });
+    const { container } = render(<ResizeEdges right={2} />);
+    const east = await waitFor(() => {
+      const el = container.querySelector<HTMLElement>(
+        '[data-resize-edge="East"]',
+      );
+      if (!el) throw new Error("east zone not rendered");
+      return el;
+    });
+    expect(east.style.width).toBe("2px");
+  });
+
+  it("renders nothing while maximized", async () => {
+    setWindowState({ maximized: true, fullscreen: false });
+    const { container } = render(<ResizeEdges />);
+    await waitFor(() => expect(isMaximized).toHaveBeenCalled());
+    expect(container.querySelectorAll("[data-resize-edge]")).toHaveLength(0);
+  });
+
+  it("renders nothing while fullscreen", async () => {
+    setWindowState({ maximized: false, fullscreen: true });
+    const { container } = render(<ResizeEdges />);
+    await waitFor(() => expect(isFullscreen).toHaveBeenCalled());
+    expect(container.querySelectorAll("[data-resize-edge]")).toHaveLength(0);
+  });
+
+  it("drops the zones when the window is maximized later", async () => {
+    setWindowState({ maximized: false, fullscreen: false });
+    const { container } = render(<ResizeEdges />);
+    await waitFor(() =>
+      expect(container.querySelectorAll("[data-resize-edge]")).toHaveLength(8),
+    );
+
+    setWindowState({ maximized: true, fullscreen: false });
+    await act(async () => {
+      resizeHandler?.();
+    });
+
+    await waitFor(() =>
+      expect(container.querySelectorAll("[data-resize-edge]")).toHaveLength(0),
+    );
+  });
+});

--- a/src/components/ResizeEdges.tsx
+++ b/src/components/ResizeEdges.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 
 type ResizeDir =
@@ -67,19 +68,52 @@ function buildZones(top: number, bottom: number, left: number, right: number) {
   return zones;
 }
 
+// Maximized / fullscreen windows can't be edge-resized, and these strips sit on
+// top of the content scrollbars — so don't render them at all in those states.
+function useWindowFills() {
+  const [fills, setFills] = useState(false);
+
+  useEffect(() => {
+    const win = getCurrentWindow();
+    let cancelled = false;
+
+    const sync = () => {
+      Promise.all([win.isMaximized(), win.isFullscreen()])
+        .then(([maximized, fullscreen]) => {
+          if (!cancelled) setFills(maximized || fullscreen);
+        })
+        .catch(() => {});
+    };
+
+    sync();
+    const unlisten = win.onResized(sync);
+
+    return () => {
+      cancelled = true;
+      unlisten.then((fn) => fn()).catch(() => {});
+    };
+  }, []);
+
+  return fills;
+}
+
 export default function ResizeEdges({
   top = 4,
   bottom = 4,
   left = 4,
   right = 4,
 }: ResizeEdgesProps) {
+  const fills = useWindowFills();
   const zones = buildZones(top, bottom, left, right);
+
+  if (fills) return null;
 
   return (
     <>
       {zones.map((zone) => (
         <div
           key={zone.direction}
+          data-resize-edge={zone.direction}
           onMouseDown={(e) => {
             e.preventDefault();
             getCurrentWindow().startResizeDragging(zone.direction);


### PR DESCRIPTION
Fixes the scrollbar half of #189.

## Bugs

The 4px invisible window-resize strip on the right edge sits on top of the content scrollbar and `preventDefault`s every mousedown, so the strip wins the drag. How bad that is depends on the view:

| View | Scrollbar | Grabbable before |
|---|---|---|
| Album, Playlist, Artist, Favorites, Mix, Library, Profile | 6px global bar | 2px — draggable, but a fiddly target |
| Home, Search, View-all, Explore | 4px `.custom-scrollbar` | **0px — completely dead** |

Those seven views own their scroll container, so they get the 6px global bar and the strip covers only its outer 4px, leaving a 2px sliver. The other four have no scroller of their own and fall through to the layout's 4px `.custom-scrollbar`, which the strip covers entirely — and Home is where the app opens, which is why the report says it never works.

Both cases now get an 8px grab band. The thumb is unchanged visually (6px and 4px respectively): the extra width is a transparent border, not a fatter bar.

Two smaller problems in the same area:

- `scrollbar-thin` / `scrollbar-thumb-*` on ten components emit no CSS at all — Tailwind v4 with no scrollbar plugin — so those views silently fall back to the global bar rather than the thin one they ask for. Left alone here; worth a separate cleanup.
- The edge-resize strips stayed active while maximized and while fullscreen, where the window cannot be resized. There they could only steal clicks.
