### PR TITLE
feat(shortcuts): align the keymap to a standard convention and fix Escape layering

### DIFF
--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useRef } from "react";
 import { getVersion } from "@tauri-apps/api/app";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { X, Heart, CircleDot } from "lucide-react";
+import { useEscapeDismiss } from "../hooks/useEscapeDismiss";
+import { DISMISS_PRIORITY } from "../lib/dismissStack";
 
 interface AboutModalProps {
   open: boolean;
@@ -53,14 +55,7 @@ export default function AboutModal({ open, onClose }: AboutModalProps) {
     return () => document.removeEventListener("mousedown", handler);
   }, [open, onClose]);
 
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [open, onClose]);
+  useEscapeDismiss(open, onClose, DISMISS_PRIORITY.modal);
 
   if (!open) return null;
 

--- a/src/components/AddToPlaylistMenu.tsx
+++ b/src/components/AddToPlaylistMenu.tsx
@@ -7,6 +7,8 @@ import { allPlaylistsAtom, addedToFolderAtom } from "../atoms/playlists";
 import { authTokensAtom } from "../atoms/auth";
 import { getAllPlaylists } from "../api/tidal";
 import { useContextMenu } from "../hooks/useContextMenu";
+import { useEscapeDismiss } from "../hooks/useEscapeDismiss";
+import { DISMISS_PRIORITY } from "../lib/dismissStack";
 import { type Playlist, getTidalImageUrl } from "../types";
 import { playlistCountLabel } from "../utils/itemHelpers";
 import TidalImage from "./TidalImage";
@@ -70,14 +72,7 @@ export function CreatePlaylistModal({
     titleRef.current?.focus();
   }, []);
 
-  // Close on Escape
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [onClose]);
+  useEscapeDismiss(true, onClose, DISMISS_PRIORITY.contextMenu);
 
   const handleSave = useCallback(async () => {
     if (!title.trim() || saving) return;
@@ -246,13 +241,7 @@ export function EditPlaylistModal({
     titleRef.current?.focus();
   }, []);
 
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [onClose]);
+  useEscapeDismiss(true, onClose, DISMISS_PRIORITY.contextMenu);
 
   const handleSave = useCallback(async () => {
     if (!title.trim() || saving) return;

--- a/src/components/AppInitializer.tsx
+++ b/src/components/AppInitializer.tsx
@@ -17,6 +17,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { parseTidalUrl } from "../lib/tidalUrl";
 import { updateToastSeenAtom } from "../atoms/updates";
 import { shouldShowUpdateToast, type UpdateInfo } from "../lib/updateToast";
+import { refreshApp } from "../lib/refreshApp";
 
 // Atoms — write-only setters (no re-render from reading)
 import {
@@ -81,7 +82,6 @@ import { useOverlayBridge } from "../hooks/useOverlayBridge";
 import { useToast } from "../contexts/ToastContext";
 import {
   checkNetworkError,
-  clearCache,
   savePlaybackQueue,
   loadPlaybackQueue,
   getHomePage,
@@ -1269,10 +1269,7 @@ export function AppInitializer() {
     focusSearch: () => {
       window.dispatchEvent(new CustomEvent("focus-search"));
     },
-    refreshData: () => {
-      clearCache();
-      window.location.reload();
-    },
+    refreshData: () => void refreshApp(),
     closeDrawer: () => {
       if (store.get(maximizedPlayerAtom)) return;
       setDrawerOpen(false);

--- a/src/components/AppInitializer.tsx
+++ b/src/components/AppInitializer.tsx
@@ -1266,9 +1266,7 @@ export function AppInitializer() {
         addFavoriteTrack(track.id, track);
       }
     },
-    toggleShuffle: () => {
-      store.set(shuffleAtom, !store.get(shuffleAtom));
-    },
+    toggleShuffle,
     toggleRepeat: () => {
       store.set(repeatAtom, (store.get(repeatAtom) + 1) % 3);
     },

--- a/src/components/AppInitializer.tsx
+++ b/src/components/AppInitializer.tsx
@@ -1274,10 +1274,6 @@ export function AppInitializer() {
       window.dispatchEvent(new CustomEvent("focus-search"));
     },
     refreshData: () => void refreshApp(),
-    closeDrawer: () => {
-      if (store.get(maximizedPlayerAtom)) return;
-      setDrawerOpen(false);
-    },
     toggleExclusive: () => {
       const isExclusive = store.get(exclusiveModeAtom);
       if (isExclusive) {

--- a/src/components/AppInitializer.tsx
+++ b/src/components/AppInitializer.tsx
@@ -1266,6 +1266,12 @@ export function AppInitializer() {
         addFavoriteTrack(track.id, track);
       }
     },
+    toggleShuffle: () => {
+      store.set(shuffleAtom, !store.get(shuffleAtom));
+    },
+    toggleRepeat: () => {
+      store.set(repeatAtom, (store.get(repeatAtom) + 1) % 3);
+    },
     focusSearch: () => {
       window.dispatchEvent(new CustomEvent("focus-search"));
     },

--- a/src/components/FolderContextMenu.tsx
+++ b/src/components/FolderContextMenu.tsx
@@ -10,6 +10,8 @@ import { useAtomValue, useSetAtom } from "jotai";
 import { useToast } from "../contexts/ToastContext";
 import { useFolders } from "../hooks/useFolders";
 import { useContextMenu } from "../hooks/useContextMenu";
+import { useEscapeDismiss } from "../hooks/useEscapeDismiss";
+import { DISMISS_PRIORITY } from "../lib/dismissStack";
 import { currentViewAtom } from "../atoms/navigation";
 import { CreatePlaylistModal } from "./AddToPlaylistMenu";
 import MenuPortal from "./MenuPortal";
@@ -49,14 +51,7 @@ function RenameFolderModal({
     }
   }, []);
 
-  // Close on Escape
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [onClose]);
+  useEscapeDismiss(true, onClose, DISMISS_PRIORITY.contextMenu);
 
   const canSave = name.trim().length > 0 && name.trim() !== currentName;
 

--- a/src/components/Layout.test.tsx
+++ b/src/components/Layout.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { render } from "@testing-library/react";
+import { Provider, createStore } from "jotai";
+
+// jsdom has no Element.prototype.scrollTo; Layout's effect calls it.
+beforeAll(() => {
+  if (!Element.prototype.scrollTo) {
+    Element.prototype.scrollTo = () => {};
+  }
+});
+
+vi.mock("./Sidebar", () => ({ default: () => <div /> }));
+vi.mock("./Header", () => ({ default: () => <div /> }));
+vi.mock("./PlayerBar", () => ({ default: () => <div /> }));
+vi.mock("./NowPlayingDrawer", () => ({ default: () => <div /> }));
+vi.mock("./TitleBar", () => ({ default: () => <div /> }));
+vi.mock("./ResizeEdges", () => ({ default: () => <div /> }));
+vi.mock("./MaximizedPlayer", () => ({ default: () => <div /> }));
+vi.mock("./VideoPlayer", () => ({ default: () => <div /> }));
+vi.mock("../hooks/useMiniplayerEmitter", () => ({
+  useMiniplayerEmitter: () => {},
+}));
+
+import Layout from "./Layout";
+
+function renderLayout() {
+  const store = createStore();
+  return render(
+    <Provider store={store}>
+      <Layout>
+        <div data-testid="child" />
+      </Layout>
+    </Provider>,
+  );
+}
+
+describe("Layout", () => {
+  it("makes the scroll container focusable so arrow keys can scroll it", () => {
+    const { container } = renderLayout();
+    const scroller = container.querySelector(".custom-scrollbar");
+    expect(scroller).not.toBeNull();
+    expect(scroller!.getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("focuses the scroll container on mount", () => {
+    const { container } = renderLayout();
+    const scroller = container.querySelector(".custom-scrollbar");
+    expect(document.activeElement).toBe(scroller);
+  });
+});

--- a/src/components/Layout.test.tsx
+++ b/src/components/Layout.test.tsx
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeAll } from "vitest";
-import { render } from "@testing-library/react";
+import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
+import { render, cleanup, act } from "@testing-library/react";
 import { Provider, createStore } from "jotai";
+import type { ReactNode } from "react";
 
 // jsdom has no Element.prototype.scrollTo; Layout's effect calls it.
 beforeAll(() => {
@@ -22,19 +23,21 @@ vi.mock("../hooks/useMiniplayerEmitter", () => ({
 }));
 
 import Layout from "./Layout";
+import { currentViewAtom } from "../atoms/navigation";
 
-function renderLayout() {
+function renderLayout(children: ReactNode = null) {
   const store = createStore();
-  return render(
+  const view = render(
     <Provider store={store}>
-      <Layout>
-        <div data-testid="child" />
-      </Layout>
+      <Layout>{children}</Layout>
     </Provider>,
   );
+  return { ...view, store };
 }
 
 describe("Layout", () => {
+  afterEach(cleanup);
+
   it("makes the scroll container focusable so arrow keys can scroll it", () => {
     const { container } = renderLayout();
     const scroller = container.querySelector(".custom-scrollbar");
@@ -46,5 +49,30 @@ describe("Layout", () => {
     const { container } = renderLayout();
     const scroller = container.querySelector(".custom-scrollbar");
     expect(document.activeElement).toBe(scroller);
+  });
+
+  it("refocuses the scroll container when the view changes", () => {
+    const { container, store } = renderLayout(<button>Play</button>);
+    const scroller = container.querySelector(".custom-scrollbar");
+    const button = container.querySelector("button")!;
+    button.focus();
+    expect(document.activeElement).toBe(button);
+
+    act(() => {
+      store.set(currentViewAtom, { type: "album", albumId: 1 });
+    });
+    expect(document.activeElement).toBe(scroller);
+  });
+
+  it("leaves focus in a text field when the view changes", () => {
+    const { container, store } = renderLayout(<input />);
+    const input = container.querySelector("input")!;
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    act(() => {
+      store.set(currentViewAtom, { type: "album", albumId: 1 });
+    });
+    expect(document.activeElement).toBe(input);
   });
 });

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -36,8 +36,21 @@ export default function Layout({ children }: LayoutProps) {
 
   useMiniplayerEmitter();
 
+  // Focus alongside the scroll reset: the container has to own focus for bare
+  // arrow keys to scroll it, and nothing else would give it focus before the
+  // first click.
   useEffect(() => {
-    scrollRef.current?.scrollTo(0, 0);
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTo(0, 0);
+    const active = document.activeElement;
+    if (
+      active instanceof HTMLInputElement ||
+      active instanceof HTMLTextAreaElement
+    ) {
+      return;
+    }
+    el.focus({ preventScroll: true });
   }, [currentView]);
 
   // ── Middle-mouse autoscroll (Chrome-style) ──
@@ -113,7 +126,8 @@ export default function Layout({ children }: LayoutProps) {
           <div
             ref={scrollRef}
             onMouseDown={onMouseDown}
-            className="flex-1 overflow-y-auto custom-scrollbar relative"
+            tabIndex={-1}
+            className="flex-1 overflow-y-auto custom-scrollbar relative outline-none"
           >
             {children}
           </div>

--- a/src/components/MaximizedPlayer.tsx
+++ b/src/components/MaximizedPlayer.tsx
@@ -27,6 +27,8 @@ import {
 import { authTokensAtom } from "../atoms/auth";
 import { usePlaybackActions } from "../hooks/usePlaybackActions";
 import { useProgressScrub } from "../hooks/useProgressScrub";
+import { useEscapeDismiss } from "../hooks/useEscapeDismiss";
+import { DISMISS_PRIORITY } from "../lib/dismissStack";
 import { getTidalImageUrl, getTrackDisplayTitle } from "../types";
 import ExplicitBadge from "./ExplicitBadge";
 import TidalImage, { fetchCachedImageUrl } from "./TidalImage";
@@ -881,16 +883,7 @@ export default function MaximizedPlayer() {
     };
   }, []);
 
-  // ESC to close — yields to context menu if open
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key !== "Escape") return;
-      if (contextMenuTrack) return;
-      setMaximized(false);
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [setMaximized, contextMenuTrack]);
+  useEscapeDismiss(true, () => setMaximized(false), DISMISS_PRIORITY.overlay);
 
   if (!currentTrack) return null;
 

--- a/src/components/MaximizedPlayer.tsx
+++ b/src/components/MaximizedPlayer.tsx
@@ -883,7 +883,13 @@ export default function MaximizedPlayer() {
     };
   }, []);
 
-  useEscapeDismiss(true, () => setMaximized(false), DISMISS_PRIORITY.overlay);
+  // Trackless (MPRIS set-fullscreen with nothing playing) renders nothing, so
+  // registering would swallow an Escape for an invisible layer.
+  useEscapeDismiss(
+    Boolean(currentTrack),
+    () => setMaximized(false),
+    DISMISS_PRIORITY.overlay,
+  );
 
   if (!currentTrack) return null;
 

--- a/src/components/MoveToFolderMenu.tsx
+++ b/src/components/MoveToFolderMenu.tsx
@@ -11,6 +11,8 @@ import { useAtom, useSetAtom } from "jotai";
 import { useToast } from "../contexts/ToastContext";
 import { useFolders, getRecentFolderIds } from "../hooks/useFolders";
 import { useContextMenu } from "../hooks/useContextMenu";
+import { useEscapeDismiss } from "../hooks/useEscapeDismiss";
+import { DISMISS_PRIORITY } from "../lib/dismissStack";
 import { getPlaylistFolders, normalizePlaylistFolders } from "../api/tidal";
 import { folderSubtitle } from "../utils/itemHelpers";
 import {
@@ -61,14 +63,7 @@ function CreateFolderModal({
     nameRef.current?.focus();
   }, []);
 
-  // Close on Escape
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [onClose]);
+  useEscapeDismiss(true, onClose, DISMISS_PRIORITY.contextMenu);
 
   const handleSave = useCallback(async () => {
     if (!name.trim() || saving) return;

--- a/src/components/NowPlayingDrawer.escape.test.tsx
+++ b/src/components/NowPlayingDrawer.escape.test.tsx
@@ -1,0 +1,69 @@
+import { afterEach, describe, it, expect, vi } from "vitest";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { Provider, createStore } from "jotai";
+
+// The real drawer and the real track menu both reach the Tauri bridge (image
+// bytes, favourites, playlists) — stub it so neither hits a backend.
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(() => Promise.resolve(undefined)),
+}));
+
+import NowPlayingDrawer from "./NowPlayingDrawer";
+import { ToastProvider } from "../contexts/ToastContext";
+import { currentTrackAtom } from "../atoms/playback";
+import { drawerOpenAtom } from "../atoms/ui";
+import type { Track } from "../types";
+
+const track = {
+  id: 1,
+  title: "Song",
+  duration: 100,
+  artist: { id: 2, name: "Artist" },
+  artists: [{ id: 2, name: "Artist" }],
+  album: { id: 3, title: "Album", cover: "cover" },
+} as unknown as Track;
+
+function escape() {
+  act(() => {
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+  });
+}
+
+function renderDrawer() {
+  const store = createStore();
+  store.set(currentTrackAtom, track);
+  store.set(drawerOpenAtom, true);
+  render(
+    <Provider store={store}>
+      <ToastProvider>
+        <NowPlayingDrawer />
+      </ToastProvider>
+    </Provider>,
+  );
+  return store;
+}
+
+describe("Escape over the now-playing drawer", () => {
+  afterEach(cleanup);
+
+  it("closes a context menu opened over the drawer, then the drawer", () => {
+    const store = renderDrawer();
+    fireEvent.click(screen.getAllByTitle("More options")[0]);
+    expect(screen.getByText("Add to play queue")).not.toBeNull();
+
+    escape();
+    expect(screen.queryByText("Add to play queue")).toBeNull();
+    expect(store.get(drawerOpenAtom)).toBe(true);
+
+    escape();
+    expect(store.get(drawerOpenAtom)).toBe(false);
+  });
+});

--- a/src/components/NowPlayingDrawer.tsx
+++ b/src/components/NowPlayingDrawer.tsx
@@ -40,6 +40,8 @@ import { usePlaybackActions } from "../hooks/usePlaybackActions";
 import { useDrawer } from "../hooks/useDrawer";
 import { useFavorites } from "../hooks/useFavorites";
 import { useNavigation } from "../hooks/useNavigation";
+import { useEscapeDismiss } from "../hooks/useEscapeDismiss";
+import { DISMISS_PRIORITY } from "../lib/dismissStack";
 import { useToast } from "../contexts/ToastContext";
 import { getInterpolatedPosition } from "../lib/playbackPosition";
 import {
@@ -1565,6 +1567,11 @@ export default function NowPlayingDrawer() {
   const videoCovers = useAtomValue(videoCoversAtom);
   const animatedCover = videoCovers && Boolean(currentTrack?.album?.videoCover);
   const { drawerOpen, setDrawerOpen, drawerTab, setDrawerTab } = useDrawer();
+  useEscapeDismiss(
+    drawerOpen,
+    () => setDrawerOpen(false),
+    DISMISS_PRIORITY.drawer,
+  );
   const setMaximized = useSetAtom(maximizedPlayerAtom);
   const activeTab = (drawerTab || "queue") as TabId;
   const setActiveTab = (tab: TabId) => setDrawerTab(tab);

--- a/src/components/ProfileEditModal.tsx
+++ b/src/components/ProfileEditModal.tsx
@@ -8,6 +8,8 @@ import {
   uploadProfilePicture,
 } from "../api/tidal";
 import { useToast } from "../contexts/ToastContext";
+import { useEscapeDismiss } from "../hooks/useEscapeDismiss";
+import { DISMISS_PRIORITY } from "../lib/dismissStack";
 import { safeErrorMessage } from "../lib/errorUtils";
 import { splitLinks, assembleExternalLinks } from "../lib/socialLinks";
 import SocialMediaPanel from "./SocialMediaPanel";
@@ -67,14 +69,7 @@ export default function ProfileEditModal({
     };
   }, [open, profile.pictureFiles]);
 
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [open, onClose]);
+  useEscapeDismiss(open, onClose, DISMISS_PRIORITY.modal);
 
   if (!open) return null;
 

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -151,6 +151,8 @@ export default function SearchBar() {
       addToHistory(searchQuery.trim());
       navigateToSearch(searchQuery.trim());
     } else if (e.key === "Escape") {
+      // A focused input owns Escape; keep it off the dismissal stack.
+      e.stopPropagation();
       setSearchOpen(false);
       searchInputRef.current?.blur();
     }
@@ -164,7 +166,7 @@ export default function SearchBar() {
     searchInputRef.current?.focus();
   };
 
-  // Listen for global Ctrl+S focus event
+  // Listen for global Ctrl+K focus event
   useEffect(() => {
     const handler = () => {
       searchInputRef.current?.focus();

--- a/src/components/SignalPathPanel.tsx
+++ b/src/components/SignalPathPanel.tsx
@@ -22,6 +22,8 @@ import {
   gainFactorToDb,
 } from "./signal-path/types";
 import { useSignalPathRefresh } from "../hooks/useSignalPathRefresh";
+import { useEscapeDismiss } from "../hooks/useEscapeDismiss";
+import { DISMISS_PRIORITY } from "../lib/dismissStack";
 
 interface SignalPathPanelProps {
   open: boolean;
@@ -51,14 +53,7 @@ export default function SignalPathPanel({
     return () => document.removeEventListener("mousedown", handler);
   }, [open, onClose]);
 
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [open, onClose]);
+  useEscapeDismiss(open, onClose, DISMISS_PRIORITY.modal);
 
   // Reset expanded state when the modal closes so it always opens at the
   // compact verdict, not where the user left it.

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -64,7 +64,12 @@ export default function UserMenu() {
 
   // Toggle shortcuts modal from ? key
   useEffect(() => {
-    const handler = () => setShortcutsOpen((prev) => !prev);
+    // Close the dropdown too — left open it sits above the modal on the
+    // dismissal stack and eats the first Escape.
+    const handler = () => {
+      setOpen(false);
+      setShortcutsOpen((prev) => !prev);
+    };
     window.addEventListener("toggle-shortcuts", handler);
     return () => window.removeEventListener("toggle-shortcuts", handler);
   }, []);

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -378,15 +378,26 @@ export default function UserMenu() {
             <div className="px-5 pb-3 flex flex-col gap-0.5 overflow-y-auto min-h-0">
               {ACTION_REGISTRY.map((action) => {
                 const isEditing = editingId === action.id;
-                const binding = bindings[action.id];
+                const binding = action.fixed
+                  ? action.default
+                  : bindings[action.id];
                 return (
                   <div
                     key={action.id}
-                    onDoubleClick={() => {
-                      setReservedHint(false);
-                      setEditingId(action.id);
-                    }}
-                    className="flex items-center justify-between py-2 px-2 rounded hover:bg-th-inset cursor-pointer select-none"
+                    title={action.fixed ? "Not rebindable" : undefined}
+                    onDoubleClick={
+                      action.fixed
+                        ? undefined
+                        : () => {
+                            setReservedHint(false);
+                            setEditingId(action.id);
+                          }
+                    }
+                    className={`flex items-center justify-between py-2 px-2 rounded select-none ${
+                      action.fixed
+                        ? "opacity-60"
+                        : "hover:bg-th-inset cursor-pointer"
+                    }`}
                   >
                     <span className="text-[13px] text-th-text-secondary">
                       {action.label}

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -14,6 +14,8 @@ import { useAtom, useAtomValue } from "jotai";
 import { useAuth } from "../hooks/useAuth";
 import { useNavigation } from "../hooks/useNavigation";
 import { usePlaybackActions } from "../hooks/usePlaybackActions";
+import { useEscapeDismiss } from "../hooks/useEscapeDismiss";
+import { DISMISS_PRIORITY } from "../lib/dismissStack";
 import {
   exclusiveModeAtom,
   bitPerfectAtom,
@@ -134,18 +136,14 @@ export default function UserMenu() {
     return () => document.removeEventListener("mousedown", handler);
   }, [open]);
 
-  // Close dropdown on Escape
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        setOpen(false);
-        setDeviceDropdownOpen(false);
-      }
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [open]);
+  useEscapeDismiss(
+    open,
+    () => {
+      setOpen(false);
+      setDeviceDropdownOpen(false);
+    },
+    DISMISS_PRIORITY.contextMenu,
+  );
 
   const menuItemClass =
     "w-full flex items-center gap-3 px-4 py-2.5 text-[13px] text-th-text-secondary hover:text-th-text-primary hover:bg-th-border-subtle transition-colors";

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -25,6 +25,7 @@ import { currentUserAvatarAtom } from "../atoms/auth";
 import { useToast } from "../contexts/ToastContext";
 import {
   ACTION_REGISTRY,
+  FIXED_KEY_DOCS,
   DEFAULT_BINDINGS,
   shortcutsAtom,
   formatCombo,
@@ -428,6 +429,20 @@ export default function UserMenu() {
                   </div>
                 );
               })}
+              {FIXED_KEY_DOCS.map((doc) => (
+                <div
+                  key={doc.label}
+                  title="Not rebindable"
+                  className="flex items-center justify-between py-2 px-2 rounded select-none opacity-60"
+                >
+                  <span className="text-[13px] text-th-text-secondary">
+                    {doc.label}
+                  </span>
+                  <kbd className="text-[12px] font-mono px-2.5 py-1 rounded-md border bg-th-surface text-th-text-muted border-th-border-subtle">
+                    {formatCombo(doc.combo)}
+                  </kbd>
+                </div>
+              ))}
             </div>
             <div className="border-t border-th-border-subtle px-5 py-3 flex justify-between items-center">
               <span className="text-[11px] text-th-text-muted">

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -145,6 +145,16 @@ export default function UserMenu() {
     DISMISS_PRIORITY.contextMenu,
   );
 
+  useEscapeDismiss(
+    shortcutsOpen,
+    () => {
+      setShortcutsOpen(false);
+      setEditingId(null);
+      setReservedHint(false);
+    },
+    DISMISS_PRIORITY.modal,
+  );
+
   const menuItemClass =
     "w-full flex items-center gap-3 px-4 py-2.5 text-[13px] text-th-text-secondary hover:text-th-text-primary hover:bg-th-border-subtle transition-colors";
 

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -33,6 +33,8 @@ import {
 import { useVideoPlayback, type VideoQuality } from "../hooks/useVideoPlayback";
 import { usePlaybackActions } from "../hooks/usePlaybackActions";
 import { useFavorites } from "../hooks/useFavorites";
+import { useEscapeDismiss } from "../hooks/useEscapeDismiss";
+import { DISMISS_PRIORITY } from "../lib/dismissStack";
 import {
   volumeAtom,
   shuffleAtom,
@@ -460,13 +462,11 @@ export default function VideoPlayer() {
     return () => clearTimeout(hideTimerRef.current);
   }, [resetHideTimer]);
 
-  // ESC closes (exits fullscreen first if active) — but only when the overlay is
-  // actually on screen. A minimized/background video must survive an ESC meant for
-  // dismissing a menu, search box, or other UI.
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key !== "Escape") return;
-      if (!expanded) return;
+  // Escape exits fullscreen first, then closes. Registering on `expanded` is what
+  // keeps a minimized background video from swallowing the key.
+  useEscapeDismiss(
+    expanded,
+    () => {
       if (fullscreen) {
         setFullscreen(false);
         getCurrentWindow()
@@ -475,10 +475,9 @@ export default function VideoPlayer() {
         return;
       }
       closeVideo();
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [expanded, fullscreen, setFullscreen, closeVideo]);
+    },
+    DISMISS_PRIORITY.overlay,
+  );
 
   if (!video) return null;
 

--- a/src/components/settings/SettingsSheet.tsx
+++ b/src/components/settings/SettingsSheet.tsx
@@ -12,6 +12,8 @@ import {
   Tv2,
   type LucideIcon,
 } from "lucide-react";
+import { useEscapeDismiss } from "../../hooks/useEscapeDismiss";
+import { DISMISS_PRIORITY } from "../../lib/dismissStack";
 import PlaybackTab from "./PlaybackTab";
 import ThemesTab from "./ThemesTab";
 import ScrobbleTab from "./ScrobbleTab";
@@ -101,14 +103,7 @@ export default function SettingsSheet({
     return () => document.removeEventListener("mousedown", handler);
   }, [open, onClose]);
 
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [open, onClose]);
+  useEscapeDismiss(open, onClose, DISMISS_PRIORITY.modal);
 
   if (!open) return null;
 

--- a/src/components/settings/UtilitiesTab.tsx
+++ b/src/components/settings/UtilitiesTab.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { Folder } from "lucide-react";
-import { clearAllCache } from "../../api/tidal";
+import { refreshApp } from "../../lib/refreshApp";
 import Toggle from "../Toggle";
 import SettingRow from "./SettingRow";
 
@@ -71,10 +71,7 @@ export default function UtilitiesTab() {
           subtitle="Clear cache and reload the application"
         >
           <button
-            onClick={async () => {
-              await clearAllCache();
-              window.location.reload();
-            }}
+            onClick={() => void refreshApp()}
             className="px-3 py-1 text-[12px] border border-th-border-subtle rounded-md text-th-text-secondary hover:text-th-text-primary hover:border-th-accent/50 transition-colors shrink-0"
           >
             Refresh

--- a/src/hooks/useContextMenu.ts
+++ b/src/hooks/useContextMenu.ts
@@ -5,6 +5,8 @@ import {
   type RefObject,
   type CSSProperties,
 } from "react";
+import { useEscapeDismiss } from "./useEscapeDismiss";
+import { DISMISS_PRIORITY } from "../lib/dismissStack";
 
 interface UseContextMenuOptions {
   cursorPosition?: { x: number; y: number };
@@ -80,7 +82,9 @@ export function useContextMenu({
     return () => cancelAnimationFrame(raf);
   }, [cursorPosition, anchorRef, anchorGap]);
 
-  // Dismiss on click-outside / Escape
+  useEscapeDismiss(!suppressClose, onClose, DISMISS_PRIORITY.contextMenu);
+
+  // Dismiss on click-outside
   useEffect(() => {
     if (suppressClose) return;
 
@@ -92,15 +96,9 @@ export function useContextMenu({
       onClose();
     };
 
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-
     document.addEventListener("mousedown", handleMouseDown);
-    document.addEventListener("keydown", handleKeyDown);
     return () => {
       document.removeEventListener("mousedown", handleMouseDown);
-      document.removeEventListener("keydown", handleKeyDown);
     };
   }, [onClose, anchorRef, ignoreRefs, suppressClose]);
 

--- a/src/hooks/useEscapeDismiss.test.tsx
+++ b/src/hooks/useEscapeDismiss.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { renderHook, cleanup } from "@testing-library/react";
 import { useEscapeDismiss } from "./useEscapeDismiss";
 import { DISMISS_PRIORITY } from "../lib/dismissStack";
@@ -10,12 +10,14 @@ function escape() {
 }
 
 describe("useEscapeDismiss", () => {
+  // The dismiss stack is module state — a failed assertion must not leak an entry.
+  afterEach(cleanup);
+
   it("dismisses while active", () => {
     const onClose = vi.fn();
     renderHook(() => useEscapeDismiss(true, onClose));
     escape();
     expect(onClose).toHaveBeenCalledTimes(1);
-    cleanup();
   });
 
   it("does not register while inactive", () => {
@@ -23,7 +25,6 @@ describe("useEscapeDismiss", () => {
     renderHook(() => useEscapeDismiss(false, onClose));
     escape();
     expect(onClose).not.toHaveBeenCalled();
-    cleanup();
   });
 
   it("registers and unregisters as active flips", () => {
@@ -40,7 +41,6 @@ describe("useEscapeDismiss", () => {
     rerender({ active: false });
     escape();
     expect(onClose).toHaveBeenCalledTimes(1);
-    cleanup();
   });
 
   it("unregisters on unmount", () => {
@@ -64,7 +64,6 @@ describe("useEscapeDismiss", () => {
     escape();
     expect(second).toHaveBeenCalledTimes(1);
     expect(first).not.toHaveBeenCalled();
-    cleanup();
   });
 
   it("keeps its place in the stack when the callback identity changes", () => {
@@ -82,7 +81,6 @@ describe("useEscapeDismiss", () => {
     escape();
     expect(top).toHaveBeenCalledTimes(1);
     expect(lower).not.toHaveBeenCalled();
-    cleanup();
   });
 
   it("respects the priority argument", () => {
@@ -95,6 +93,5 @@ describe("useEscapeDismiss", () => {
     escape();
     expect(menu).toHaveBeenCalledTimes(1);
     expect(drawer).not.toHaveBeenCalled();
-    cleanup();
   });
 });

--- a/src/hooks/useEscapeDismiss.test.tsx
+++ b/src/hooks/useEscapeDismiss.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, cleanup } from "@testing-library/react";
+import { useEscapeDismiss } from "./useEscapeDismiss";
+import { DISMISS_PRIORITY } from "../lib/dismissStack";
+
+function escape() {
+  window.dispatchEvent(
+    new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+  );
+}
+
+describe("useEscapeDismiss", () => {
+  it("dismisses while active", () => {
+    const onClose = vi.fn();
+    renderHook(() => useEscapeDismiss(true, onClose));
+    escape();
+    expect(onClose).toHaveBeenCalledTimes(1);
+    cleanup();
+  });
+
+  it("does not register while inactive", () => {
+    const onClose = vi.fn();
+    renderHook(() => useEscapeDismiss(false, onClose));
+    escape();
+    expect(onClose).not.toHaveBeenCalled();
+    cleanup();
+  });
+
+  it("registers and unregisters as active flips", () => {
+    const onClose = vi.fn();
+    const { rerender } = renderHook(
+      ({ active }: { active: boolean }) => useEscapeDismiss(active, onClose),
+      { initialProps: { active: false } },
+    );
+
+    rerender({ active: true });
+    escape();
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    rerender({ active: false });
+    escape();
+    expect(onClose).toHaveBeenCalledTimes(1);
+    cleanup();
+  });
+
+  it("unregisters on unmount", () => {
+    const onClose = vi.fn();
+    const { unmount } = renderHook(() => useEscapeDismiss(true, onClose));
+    unmount();
+    escape();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("calls the latest callback without re-registering", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender } = renderHook(
+      ({ cb }: { cb: () => void }) =>
+        useEscapeDismiss(true, cb, DISMISS_PRIORITY.modal),
+      { initialProps: { cb: first } },
+    );
+
+    rerender({ cb: second });
+    escape();
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(first).not.toHaveBeenCalled();
+    cleanup();
+  });
+
+  it("keeps its place in the stack when the callback identity changes", () => {
+    const lower = vi.fn();
+    const top = vi.fn();
+    const { rerender } = renderHook(
+      ({ cb }: { cb: () => void }) => {
+        useEscapeDismiss(true, cb, DISMISS_PRIORITY.modal);
+        useEscapeDismiss(true, top, DISMISS_PRIORITY.modal);
+      },
+      { initialProps: { cb: lower } },
+    );
+
+    rerender({ cb: vi.fn() });
+    escape();
+    expect(top).toHaveBeenCalledTimes(1);
+    expect(lower).not.toHaveBeenCalled();
+    cleanup();
+  });
+
+  it("respects the priority argument", () => {
+    const menu = vi.fn();
+    const drawer = vi.fn();
+    renderHook(() => useEscapeDismiss(true, drawer, DISMISS_PRIORITY.drawer));
+    renderHook(() =>
+      useEscapeDismiss(true, menu, DISMISS_PRIORITY.contextMenu),
+    );
+    escape();
+    expect(menu).toHaveBeenCalledTimes(1);
+    expect(drawer).not.toHaveBeenCalled();
+    cleanup();
+  });
+});

--- a/src/hooks/useEscapeDismiss.ts
+++ b/src/hooks/useEscapeDismiss.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import { registerDismissable, DISMISS_PRIORITY } from "../lib/dismissStack";
 
 // Registers while `active` — not merely while mounted — so a layer that is
@@ -10,7 +10,8 @@ export function useEscapeDismiss(
   priority: number = DISMISS_PRIORITY.modal,
 ): void {
   const onCloseRef = useRef(onClose);
-  useEffect(() => {
+  // Layout-phase so an Escape between render and passive flush can't run a stale closure.
+  useLayoutEffect(() => {
     onCloseRef.current = onClose;
   });
 

--- a/src/hooks/useEscapeDismiss.ts
+++ b/src/hooks/useEscapeDismiss.ts
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from "react";
+import { registerDismissable, DISMISS_PRIORITY } from "../lib/dismissStack";
+
+// Registers while `active` — not merely while mounted — so a layer that is
+// present but hidden (a minimized video) doesn't swallow Escape. The callback
+// lives in a ref so an inline arrow doesn't re-register on every render.
+export function useEscapeDismiss(
+  active: boolean,
+  onClose: () => void,
+  priority: number = DISMISS_PRIORITY.modal,
+): void {
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  });
+
+  useEffect(() => {
+    if (!active) return;
+    return registerDismissable(priority, () => onCloseRef.current());
+  }, [active, priority]);
+}

--- a/src/hooks/useShortcuts.test.tsx
+++ b/src/hooks/useShortcuts.test.tsx
@@ -74,4 +74,26 @@ describe("useShortcuts", () => {
     press({ code: "KeyR", ctrlKey: true, shiftKey: true });
     expect(refreshData).toHaveBeenCalledTimes(1);
   });
+
+  it("keeps a fixed combo when a later-sorting action stores it", () => {
+    const refreshData = vi.fn();
+    const volumeUp = vi.fn();
+    mount(
+      { refreshData, volumeUp },
+      {
+        ...DEFAULT_BINDINGS,
+        volumeUp: { code: "KeyR", mod: true, shift: true, alt: false },
+      },
+    );
+    press({ code: "KeyR", ctrlKey: true, shiftKey: true });
+    expect(refreshData).toHaveBeenCalledTimes(1);
+    expect(volumeUp).not.toHaveBeenCalled();
+  });
+
+  it("dispatches a fixed action even when storage cleared its binding", () => {
+    const refreshData = vi.fn();
+    mount({ refreshData }, { ...DEFAULT_BINDINGS, refreshData: null });
+    press({ code: "KeyR", ctrlKey: true, shiftKey: true });
+    expect(refreshData).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/hooks/useShortcuts.test.tsx
+++ b/src/hooks/useShortcuts.test.tsx
@@ -12,6 +12,10 @@ function press(init: KeyboardEventInit) {
   );
 }
 
+function pressIn(el: HTMLElement, init: KeyboardEventInit) {
+  el.dispatchEvent(new KeyboardEvent("keydown", { ...init, bubbles: true }));
+}
+
 function mount(
   dispatch: Parameters<typeof useShortcuts>[0],
   bindings = DEFAULT_BINDINGS,
@@ -58,6 +62,24 @@ describe("useShortcuts", () => {
     press({ code: "KeyR", altKey: true });
     expect(toggleShuffle).toHaveBeenCalledTimes(1);
     expect(toggleRepeat).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps Alt combos live in a text field while bare letters stay muted", () => {
+    const toggleShuffle = vi.fn();
+    const muteToggle = vi.fn();
+    mount({ toggleShuffle, muteToggle });
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    pressIn(input, { code: "KeyM" });
+    expect(muteToggle).not.toHaveBeenCalled();
+
+    pressIn(input, { code: "KeyS", altKey: true });
+    expect(toggleShuffle).toHaveBeenCalledTimes(1);
+
+    input.remove();
   });
 
   it("dispatches a fixed action on its default even when storage moved it", () => {

--- a/src/hooks/useShortcuts.test.tsx
+++ b/src/hooks/useShortcuts.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, cleanup } from "@testing-library/react";
+import { Provider, createStore } from "jotai";
+import type { PropsWithChildren } from "react";
+
+import { useShortcuts } from "./useShortcuts";
+import { shortcutsAtom, DEFAULT_BINDINGS } from "../lib/shortcuts";
+
+function press(init: KeyboardEventInit) {
+  window.dispatchEvent(
+    new KeyboardEvent("keydown", { ...init, bubbles: true }),
+  );
+}
+
+function mount(
+  dispatch: Parameters<typeof useShortcuts>[0],
+  bindings = DEFAULT_BINDINGS,
+) {
+  const store = createStore();
+  store.set(shortcutsAtom, bindings);
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <Provider store={store}>{children}</Provider>
+  );
+  renderHook(() => useShortcuts(dispatch), { wrapper });
+}
+
+describe("useShortcuts", () => {
+  beforeEach(() => cleanup());
+
+  it("fires volume up on Ctrl+ArrowUp", () => {
+    const volumeUp = vi.fn();
+    mount({ volumeUp });
+    press({ code: "ArrowUp", ctrlKey: true });
+    expect(volumeUp).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a bare ArrowUp so it can scroll", () => {
+    const volumeUp = vi.fn();
+    mount({ volumeUp });
+    press({ code: "ArrowUp" });
+    expect(volumeUp).not.toHaveBeenCalled();
+  });
+
+  it("fires search on Ctrl+K and not on Ctrl+S", () => {
+    const focusSearch = vi.fn();
+    mount({ focusSearch });
+    press({ code: "KeyS", ctrlKey: true });
+    expect(focusSearch).not.toHaveBeenCalled();
+    press({ code: "KeyK", ctrlKey: true });
+    expect(focusSearch).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires shuffle on Alt+S and repeat on Alt+R", () => {
+    const toggleShuffle = vi.fn();
+    const toggleRepeat = vi.fn();
+    mount({ toggleShuffle, toggleRepeat });
+    press({ code: "KeyS", altKey: true });
+    press({ code: "KeyR", altKey: true });
+    expect(toggleShuffle).toHaveBeenCalledTimes(1);
+    expect(toggleRepeat).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispatches a fixed action on its default even when storage moved it", () => {
+    const refreshData = vi.fn();
+    mount(
+      { refreshData },
+      {
+        ...DEFAULT_BINDINGS,
+        refreshData: { code: "F1", mod: false, shift: false, alt: false },
+      },
+    );
+    press({ code: "F1" });
+    expect(refreshData).not.toHaveBeenCalled();
+    press({ code: "KeyR", ctrlKey: true, shiftKey: true });
+    expect(refreshData).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useShortcuts.ts
+++ b/src/hooks/useShortcuts.ts
@@ -22,7 +22,8 @@ export function useShortcuts(dispatch: ShortcutDispatch) {
   const inverse = useMemo(() => {
     const m = new Map<string, ActionId>();
     for (const id of ownedKey.split(",").filter(Boolean) as ActionId[]) {
-      const combo = bindings[id];
+      const meta = ACTION_BY_ID.get(id);
+      const combo = meta?.fixed ? meta.default : bindings[id];
       if (combo) m.set(comboKey(combo), id);
     }
     return m;

--- a/src/hooks/useShortcuts.ts
+++ b/src/hooks/useShortcuts.ts
@@ -48,7 +48,8 @@ export function useShortcuts(dispatch: ShortcutDispatch) {
       const inInput =
         e.target instanceof HTMLInputElement ||
         e.target instanceof HTMLTextAreaElement;
-      if (inInput && !combo.mod) return;
+      // Alt-modified combos type nothing, so they stay live inside text fields.
+      if (inInput && !combo.mod && !combo.alt) return;
 
       const fn = dispatchRef.current[id];
       if (!fn) return;

--- a/src/hooks/useShortcuts.ts
+++ b/src/hooks/useShortcuts.ts
@@ -20,10 +20,16 @@ export function useShortcuts(dispatch: ShortcutDispatch) {
   const ownedKey = (Object.keys(dispatch) as ActionId[]).sort().join(",");
 
   const inverse = useMemo(() => {
+    const owned = ownedKey.split(",").filter(Boolean) as ActionId[];
+    const isFixed = (id: ActionId) => ACTION_BY_ID.get(id)?.fixed === true;
     const m = new Map<string, ActionId>();
-    for (const id of ownedKey.split(",").filter(Boolean) as ActionId[]) {
-      const meta = ACTION_BY_ID.get(id);
-      const combo = meta?.fixed ? meta.default : bindings[id];
+    for (const id of owned.filter((a) => !isFixed(a))) {
+      const combo = bindings[id];
+      if (combo) m.set(comboKey(combo), id);
+    }
+    // Second pass: a fixed action's combo is reserved, so it wins any collision.
+    for (const id of owned.filter(isFixed)) {
+      const combo = ACTION_BY_ID.get(id)?.default;
       if (combo) m.set(comboKey(combo), id);
     }
     return m;

--- a/src/lib/dismissStack.test.ts
+++ b/src/lib/dismissStack.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React from "react";
+import { render, cleanup, fireEvent } from "@testing-library/react";
 import { registerDismissable, DISMISS_PRIORITY } from "./dismissStack";
 
 function escape() {
@@ -17,6 +19,7 @@ describe("dismissStack", () => {
   afterEach(() => {
     // Never leak an entry into the next test — the stack is module state.
     cleanups.forEach((fn) => fn());
+    cleanup();
   });
 
   const register = (priority: number, onClose: () => void) => {
@@ -106,6 +109,34 @@ describe("dismissStack", () => {
 
   it("does nothing when the stack is empty", () => {
     expect(() => escape()).not.toThrow();
+  });
+
+  // A focused input owns Escape by calling stopPropagation in its React
+  // onKeyDown (see SearchBar). React attaches below window, so the key never
+  // reaches the stack — which only holds while the stack listens on bubble.
+  const renderInput = (onKeyDown: (e: React.KeyboardEvent) => void) => {
+    const { container } = render(React.createElement("input", { onKeyDown }));
+    return container.querySelector("input")!;
+  };
+
+  it("dismisses when a focused element lets the key bubble", () => {
+    const onClose = vi.fn();
+    register(DISMISS_PRIORITY.drawer, onClose);
+    fireEvent.keyDown(
+      renderInput(() => {}),
+      { key: "Escape" },
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not dismiss when a focused element stops propagation", () => {
+    const onClose = vi.fn();
+    register(DISMISS_PRIORITY.drawer, onClose);
+    fireEvent.keyDown(
+      renderInput((e) => e.stopPropagation()),
+      { key: "Escape" },
+    );
+    expect(onClose).not.toHaveBeenCalled();
   });
 
   it("tolerates a repeated unregister across a drain and reattach", () => {

--- a/src/lib/dismissStack.test.ts
+++ b/src/lib/dismissStack.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { registerDismissable, DISMISS_PRIORITY } from "./dismissStack";
+
+function escape() {
+  window.dispatchEvent(
+    new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+  );
+}
+
+describe("dismissStack", () => {
+  let cleanups: Array<() => void>;
+
+  beforeEach(() => {
+    cleanups = [];
+  });
+
+  afterEach(() => {
+    // Never leak an entry into the next test — the stack is module state.
+    cleanups.forEach((fn) => fn());
+  });
+
+  const register = (priority: number, onClose: () => void) => {
+    const off = registerDismissable(priority, onClose);
+    cleanups.push(off);
+    return off;
+  };
+
+  it("dismisses the only entry", () => {
+    const onClose = vi.fn();
+    register(DISMISS_PRIORITY.modal, onClose);
+    escape();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores keys other than Escape", () => {
+    const onClose = vi.fn();
+    register(DISMISS_PRIORITY.modal, onClose);
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+    );
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("dismisses only the most recent of two equal priorities", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    register(DISMISS_PRIORITY.modal, first);
+    register(DISMISS_PRIORITY.modal, second);
+    escape();
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(first).not.toHaveBeenCalled();
+  });
+
+  it("prefers higher priority over more recent registration", () => {
+    const menu = vi.fn();
+    const drawer = vi.fn();
+    register(DISMISS_PRIORITY.contextMenu, menu);
+    register(DISMISS_PRIORITY.drawer, drawer);
+    escape();
+    expect(menu).toHaveBeenCalledTimes(1);
+    expect(drawer).not.toHaveBeenCalled();
+  });
+
+  it("falls through to the next layer after the top one unregisters", () => {
+    const menu = vi.fn();
+    const drawer = vi.fn();
+    const offMenu = register(DISMISS_PRIORITY.contextMenu, menu);
+    register(DISMISS_PRIORITY.drawer, drawer);
+    offMenu();
+    escape();
+    expect(drawer).toHaveBeenCalledTimes(1);
+    expect(menu).not.toHaveBeenCalled();
+  });
+
+  it("closes exactly one layer per keypress", () => {
+    const a = vi.fn();
+    const b = vi.fn();
+    register(DISMISS_PRIORITY.modal, a);
+    register(DISMISS_PRIORITY.overlay, b);
+    escape();
+    expect(a.mock.calls.length + b.mock.calls.length).toBe(1);
+  });
+
+  it("attaches one listener and detaches it when empty", () => {
+    const add = vi.spyOn(window, "addEventListener");
+    const remove = vi.spyOn(window, "removeEventListener");
+
+    const offA = registerDismissable(DISMISS_PRIORITY.modal, () => {});
+    const offB = registerDismissable(DISMISS_PRIORITY.modal, () => {});
+    const addCalls = add.mock.calls.filter(([type]) => type === "keydown");
+    expect(addCalls).toHaveLength(1);
+
+    offA();
+    expect(
+      remove.mock.calls.filter(([type]) => type === "keydown"),
+    ).toHaveLength(0);
+
+    offB();
+    expect(
+      remove.mock.calls.filter(([type]) => type === "keydown"),
+    ).toHaveLength(1);
+
+    add.mockRestore();
+    remove.mockRestore();
+  });
+
+  it("does nothing when the stack is empty", () => {
+    expect(() => escape()).not.toThrow();
+  });
+});

--- a/src/lib/dismissStack.test.ts
+++ b/src/lib/dismissStack.test.ts
@@ -107,4 +107,26 @@ describe("dismissStack", () => {
   it("does nothing when the stack is empty", () => {
     expect(() => escape()).not.toThrow();
   });
+
+  it("tolerates a repeated unregister across a drain and reattach", () => {
+    const remove = vi.spyOn(window, "removeEventListener");
+    const stale = vi.fn();
+    const live = vi.fn();
+
+    const offStale = registerDismissable(DISMISS_PRIORITY.modal, stale);
+    offStale();
+    expect(() => offStale()).not.toThrow();
+
+    // The stack drained and reattached — the stale unregister must not detach it.
+    register(DISMISS_PRIORITY.modal, live);
+    offStale();
+    escape();
+    expect(live).toHaveBeenCalledTimes(1);
+    expect(stale).not.toHaveBeenCalled();
+    expect(
+      remove.mock.calls.filter(([type]) => type === "keydown"),
+    ).toHaveLength(1);
+
+    remove.mockRestore();
+  });
 });

--- a/src/lib/dismissStack.ts
+++ b/src/lib/dismissStack.ts
@@ -39,6 +39,7 @@ export function registerDismissable(
   const entry: Entry = { priority, onClose, seq: ++seq };
   entries.push(entry);
   if (!listening) {
+    // Bubble phase on purpose — a focused input's stopPropagation must win.
     window.addEventListener("keydown", onKeyDown);
     listening = true;
   }

--- a/src/lib/dismissStack.ts
+++ b/src/lib/dismissStack.ts
@@ -1,0 +1,53 @@
+// Escape dismisses exactly one layer: the visually topmost. Priority beats
+// registration order, so a context menu opened over a modal closes first
+// regardless of which mounted when.
+export const DISMISS_PRIORITY = {
+  contextMenu: 400,
+  modal: 300,
+  overlay: 200,
+  drawer: 100,
+} as const;
+
+type Entry = { priority: number; onClose: () => void; seq: number };
+
+let entries: Entry[] = [];
+let seq = 0;
+let listening = false;
+
+function onKeyDown(e: KeyboardEvent) {
+  if (e.key !== "Escape") return;
+  if (entries.length === 0) return;
+
+  let top = entries[0];
+  for (const entry of entries) {
+    if (
+      entry.priority > top.priority ||
+      (entry.priority === top.priority && entry.seq > top.seq)
+    ) {
+      top = entry;
+    }
+  }
+
+  e.preventDefault();
+  top.onClose();
+}
+
+export function registerDismissable(
+  priority: number,
+  onClose: () => void,
+): () => void {
+  const entry: Entry = { priority, onClose, seq: ++seq };
+  entries.push(entry);
+  if (!listening) {
+    window.addEventListener("keydown", onKeyDown);
+    listening = true;
+  }
+
+  return () => {
+    entries = entries.filter((e) => e !== entry);
+    if (entries.length === 0 && listening) {
+      window.removeEventListener("keydown", onKeyDown);
+      listening = false;
+    }
+  };
+}

--- a/src/lib/refreshApp.test.ts
+++ b/src/lib/refreshApp.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { clearAllCacheMock } = vi.hoisted(() => ({
+  clearAllCacheMock: vi.fn(),
+}));
+vi.mock("../api/tidal", () => ({ clearAllCache: clearAllCacheMock }));
+
+import { refreshApp } from "./refreshApp";
+
+describe("refreshApp", () => {
+  let reload: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    clearAllCacheMock.mockReset();
+    reload = vi.fn();
+    // jsdom's location.reload is non-writable — redefine it.
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, reload },
+    });
+  });
+
+  it("clears every cache before reloading", async () => {
+    const order: string[] = [];
+    clearAllCacheMock.mockImplementation(async () => {
+      order.push("clear");
+    });
+    reload.mockImplementation(() => order.push("reload"));
+
+    await refreshApp();
+
+    expect(clearAllCacheMock).toHaveBeenCalledTimes(1);
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(["clear", "reload"]);
+  });
+
+  it("still reloads when clearing rejects", async () => {
+    clearAllCacheMock.mockRejectedValue(new Error("backend down"));
+    await refreshApp();
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/refreshApp.ts
+++ b/src/lib/refreshApp.ts
@@ -1,0 +1,12 @@
+import { clearAllCache } from "../api/tidal";
+
+// Shared by the refresh shortcut and Settings → Utilities → "Refresh App" so the
+// two can't drift apart. A failed disk-cache clear must still reload.
+export async function refreshApp(): Promise<void> {
+  try {
+    await clearAllCache();
+  } catch {
+    // Backend unreachable — reload anyway; the frontend cache is already gone.
+  }
+  window.location.reload();
+}

--- a/src/lib/shortcuts.test.ts
+++ b/src/lib/shortcuts.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import {
+  migrateBindingsV1ToV2,
+  isReserved,
+  ACTION_BY_ID,
+  comboEquals,
+  type KeyCombo,
+} from "./shortcuts";
+
+const combo = (
+  code: string,
+  opts: Partial<Omit<KeyCombo, "code">> = {},
+): KeyCombo => ({
+  code,
+  mod: opts.mod ?? false,
+  shift: opts.shift ?? false,
+  alt: opts.alt ?? false,
+});
+
+// A full v1 map at v1 defaults, i.e. a user who never customised anything.
+const V1_PRISTINE = {
+  playPause: combo("Space"),
+  nextTrack: combo("ArrowRight", { mod: true }),
+  prevTrack: combo("ArrowLeft", { mod: true }),
+  volumeUp: combo("ArrowUp"),
+  volumeDown: combo("ArrowDown"),
+  muteToggle: combo("KeyM"),
+  likeToggle: combo("KeyL"),
+  focusSearch: combo("KeyS", { mod: true }),
+  refreshData: combo("KeyR", { mod: true, shift: true }),
+  closeDrawer: combo("Escape"),
+  zoomIn: combo("Equal", { mod: true }),
+  zoomOut: combo("Minus", { mod: true }),
+  zoomReset: combo("Digit0", { mod: true }),
+  toggleExclusive: combo("KeyE", { mod: true }),
+  toggleBitPerfect: combo("KeyB", { mod: true }),
+  toggleShortcuts: combo("Slash", { shift: true }),
+};
+
+const migrate = (v1: unknown) => migrateBindingsV1ToV2(JSON.stringify(v1));
+
+describe("migrateBindingsV1ToV2", () => {
+  it("returns null when there is no v1 map", () => {
+    expect(migrateBindingsV1ToV2(null)).toBeNull();
+  });
+
+  it("returns null for unparseable v1 data instead of throwing", () => {
+    expect(migrateBindingsV1ToV2("{not json")).toBeNull();
+    expect(migrateBindingsV1ToV2("null")).toBeNull();
+    expect(migrateBindingsV1ToV2('"a string"')).toBeNull();
+  });
+
+  it("moves uncustomised volume keys onto the new Ctrl+arrow defaults", () => {
+    const v2 = migrate(V1_PRISTINE)!;
+    expect(comboEquals(v2.volumeUp, combo("ArrowUp", { mod: true }))).toBe(
+      true,
+    );
+    expect(comboEquals(v2.volumeDown, combo("ArrowDown", { mod: true }))).toBe(
+      true,
+    );
+  });
+
+  it("moves uncustomised search onto Ctrl+K", () => {
+    const v2 = migrate(V1_PRISTINE)!;
+    expect(comboEquals(v2.focusSearch, combo("KeyK", { mod: true }))).toBe(
+      true,
+    );
+  });
+
+  it("preserves a customised binding", () => {
+    const v2 = migrate({ ...V1_PRISTINE, volumeUp: combo("F5") })!;
+    expect(comboEquals(v2.volumeUp, combo("F5"))).toBe(true);
+  });
+
+  it("preserves an explicitly unbound action", () => {
+    const v2 = migrate({ ...V1_PRISTINE, likeToggle: null })!;
+    expect(v2.likeToggle).toBeNull();
+  });
+
+  it("adds the new shuffle and repeat actions on Alt+S / Alt+R", () => {
+    const v2 = migrate(V1_PRISTINE)!;
+    expect(comboEquals(v2.toggleShuffle, combo("KeyS", { alt: true }))).toBe(
+      true,
+    );
+    expect(comboEquals(v2.toggleRepeat, combo("KeyR", { alt: true }))).toBe(
+      true,
+    );
+  });
+
+  it("keeps closeDrawer in Part 1", () => {
+    const v2 = migrate(V1_PRISTINE)!;
+    expect(comboEquals(v2.closeDrawer, combo("Escape"))).toBe(true);
+  });
+
+  it("forces a fixed action back to its default even if v1 moved it", () => {
+    const v2 = migrate({ ...V1_PRISTINE, refreshData: combo("F1") })!;
+    expect(
+      comboEquals(v2.refreshData, combo("KeyR", { mod: true, shift: true })),
+    ).toBe(true);
+  });
+
+  it("lets a customisation win a collision and unbinds the new default", () => {
+    const v2 = migrate({
+      ...V1_PRISTINE,
+      nextTrack: combo("KeyK", { mod: true }),
+    })!;
+    expect(comboEquals(v2.nextTrack, combo("KeyK", { mod: true }))).toBe(true);
+    expect(v2.focusSearch).toBeNull();
+  });
+
+  it("never emits the same combo twice", () => {
+    const v2 = migrate(V1_PRISTINE)!;
+    const keys = Object.values(v2)
+      .filter((c): c is KeyCombo => c !== null)
+      .map((c) => `${c.code}|${c.mod}${c.shift}${c.alt}`);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});
+
+describe("fixed actions", () => {
+  it("marks refreshData fixed", () => {
+    expect(ACTION_BY_ID.get("refreshData")?.fixed).toBe(true);
+  });
+
+  it("reserves a fixed action's combo and Ctrl+R", () => {
+    expect(isReserved(combo("KeyR", { mod: true, shift: true }))).toBe(true);
+    expect(isReserved(combo("KeyR", { mod: true }))).toBe(true);
+  });
+
+  it("does not reserve combos that are merely in use", () => {
+    expect(isReserved(combo("KeyK", { mod: true }))).toBe(false);
+  });
+});

--- a/src/lib/shortcuts.test.ts
+++ b/src/lib/shortcuts.test.ts
@@ -108,12 +108,68 @@ describe("migrateBindingsV1ToV2", () => {
     expect(v2.focusSearch).toBeNull();
   });
 
+  it("adopts the new defaults for ids absent from a partial v1 map", () => {
+    const partial: Record<string, unknown> = { ...V1_PRISTINE };
+    delete partial.volumeUp;
+    delete partial.volumeDown;
+    delete partial.focusSearch;
+    delete partial.muteToggle;
+    const v2 = migrate(partial)!;
+    expect(comboEquals(v2.volumeUp, combo("ArrowUp", { mod: true }))).toBe(
+      true,
+    );
+    expect(comboEquals(v2.volumeDown, combo("ArrowDown", { mod: true }))).toBe(
+      true,
+    );
+    expect(comboEquals(v2.focusSearch, combo("KeyK", { mod: true }))).toBe(
+      true,
+    );
+    expect(comboEquals(v2.muteToggle, combo("KeyM"))).toBe(true);
+  });
+
+  it("keeps a fixed action bound when a v1 customisation collides with it", () => {
+    const v2 = migrate({
+      ...V1_PRISTINE,
+      zoomIn: combo("KeyR", { mod: true, shift: true }),
+    })!;
+    expect(
+      comboEquals(v2.refreshData, combo("KeyR", { mod: true, shift: true })),
+    ).toBe(true);
+    expect(v2.zoomIn).toBeNull();
+  });
+
+  it("treats corrupt v1 entries as uncustomised", () => {
+    const v2 = migrate({
+      ...V1_PRISTINE,
+      volumeUp: 5,
+      muteToggle: "x",
+      likeToggle: { code: "KeyL" },
+      zoomIn: [],
+    })!;
+    expect(comboEquals(v2.volumeUp, combo("ArrowUp", { mod: true }))).toBe(
+      true,
+    );
+    expect(comboEquals(v2.muteToggle, combo("KeyM"))).toBe(true);
+    expect(comboEquals(v2.likeToggle, combo("KeyL"))).toBe(true);
+    expect(comboEquals(v2.zoomIn, combo("Equal", { mod: true }))).toBe(true);
+  });
+
   it("never emits the same combo twice", () => {
-    const v2 = migrate(V1_PRISTINE)!;
-    const keys = Object.values(v2)
-      .filter((c): c is KeyCombo => c !== null)
-      .map((c) => `${c.code}|${c.mod}${c.shift}${c.alt}`);
-    expect(new Set(keys).size).toBe(keys.length);
+    const colliding: Record<string, unknown> = {
+      ...V1_PRISTINE,
+      nextTrack: combo("KeyK", { mod: true }),
+      prevTrack: combo("ArrowUp", { mod: true }),
+      volumeDown: combo("KeyS", { alt: true }),
+      zoomIn: combo("KeyR", { mod: true, shift: true }),
+    };
+    delete colliding.focusSearch;
+
+    for (const v1 of [V1_PRISTINE, colliding]) {
+      const keys = Object.values(migrate(v1)!)
+        .filter((c): c is KeyCombo => c !== null)
+        .map((c) => `${c.code}|${c.mod}${c.shift}${c.alt}`);
+      expect(new Set(keys).size).toBe(keys.length);
+    }
   });
 });
 

--- a/src/lib/shortcuts.test.ts
+++ b/src/lib/shortcuts.test.ts
@@ -87,9 +87,9 @@ describe("migrateBindingsV1ToV2", () => {
     );
   });
 
-  it("keeps closeDrawer in Part 1", () => {
-    const v2 = migrate(V1_PRISTINE)!;
-    expect(comboEquals(v2.closeDrawer, combo("Escape"))).toBe(true);
+  it("drops closeDrawer now that the dismissal stack owns Escape", () => {
+    const v2 = migrate(V1_PRISTINE)! as Record<string, unknown>;
+    expect("closeDrawer" in v2).toBe(false);
   });
 
   it("forces a fixed action back to its default even if v1 moved it", () => {

--- a/src/lib/shortcuts.test.ts
+++ b/src/lib/shortcuts.test.ts
@@ -186,4 +186,8 @@ describe("fixed actions", () => {
   it("does not reserve combos that are merely in use", () => {
     expect(isReserved(combo("KeyK", { mod: true }))).toBe(false);
   });
+
+  it("reserves the keys the dismissal stack owns", () => {
+    expect(isReserved(combo("Escape"))).toBe(true);
+  });
 });

--- a/src/lib/shortcuts.test.ts
+++ b/src/lib/shortcuts.test.ts
@@ -3,6 +3,7 @@ import {
   migrateBindingsV1ToV2,
   isReserved,
   ACTION_BY_ID,
+  ACTION_REGISTRY,
   comboEquals,
   type KeyCombo,
 } from "./shortcuts";
@@ -135,7 +136,20 @@ describe("migrateBindingsV1ToV2", () => {
     expect(
       comboEquals(v2.refreshData, combo("KeyR", { mod: true, shift: true })),
     ).toBe(true);
-    expect(v2.zoomIn).toBeNull();
+    expect(comboEquals(v2.zoomIn, combo("Equal", { mod: true }))).toBe(true);
+  });
+
+  it("treats a v1 binding on a stack-owned key as uncustomised", () => {
+    const v2 = migrate({ ...V1_PRISTINE, zoomOut: combo("Escape") })!;
+    expect(comboEquals(v2.zoomOut, combo("Minus", { mod: true }))).toBe(true);
+  });
+
+  it("treats a v1 binding on Ctrl+R as uncustomised", () => {
+    const v2 = migrate({
+      ...V1_PRISTINE,
+      likeToggle: combo("KeyR", { mod: true }),
+    })!;
+    expect(comboEquals(v2.likeToggle, combo("KeyL"))).toBe(true);
   });
 
   it("treats corrupt v1 entries as uncustomised", () => {
@@ -189,5 +203,12 @@ describe("fixed actions", () => {
 
   it("reserves the keys the dismissal stack owns", () => {
     expect(isReserved(combo("Escape"))).toBe(true);
+  });
+
+  it("never ships a rebindable action whose default is reserved", () => {
+    for (const action of ACTION_REGISTRY) {
+      if (action.fixed) continue;
+      expect(isReserved(action.default)).toBe(false);
+    }
   });
 });

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -12,7 +12,6 @@ export const ACTION_IDS = [
   "toggleRepeat",
   "focusSearch",
   "refreshData",
-  "closeDrawer",
   "zoomIn",
   "zoomOut",
   "zoomReset",
@@ -105,11 +104,6 @@ export const ACTION_REGISTRY: readonly ActionMeta[] = [
     default: c("KeyR", { mod: true, shift: true }),
     fixed: true,
   },
-  {
-    id: "closeDrawer",
-    label: "Close now-playing drawer",
-    default: c("Escape"),
-  },
   { id: "zoomIn", label: "Zoom in", default: c("Equal", { mod: true }) },
   { id: "zoomOut", label: "Zoom out", default: c("Minus", { mod: true }) },
   {
@@ -139,6 +133,12 @@ export const ACTION_REGISTRY: readonly ActionMeta[] = [
 export const ACTION_BY_ID: ReadonlyMap<ActionId, ActionMeta> = new Map(
   ACTION_REGISTRY.map((a) => [a.id, a]),
 );
+
+// Keys the dismissal stack owns. Not bindable to any action, but listed in the
+// shortcuts panel so they stay discoverable.
+export const FIXED_KEY_DOCS: readonly { combo: KeyCombo; label: string }[] = [
+  { combo: c("Escape"), label: "Dismiss topmost overlay" },
+];
 
 export const DEFAULT_BINDINGS: Record<ActionId, KeyCombo | null> =
   Object.fromEntries(ACTION_REGISTRY.map((a) => [a.id, a.default])) as Record<
@@ -170,8 +170,9 @@ const STORAGE_KEY_V1 = "sone.shortcuts.v1";
 const STORAGE_KEY_V2 = "sone.shortcuts.v2";
 
 // Frozen snapshot of the v1 defaults. Used only to tell "user customised this"
-// apart from "user never touched this" when migrating.
-const V1_DEFAULTS: Partial<Record<ActionId, KeyCombo>> = {
+// apart from "user never touched this" when migrating. Keyed by string because
+// it still describes ids that have since been retired.
+const V1_DEFAULTS: Record<string, KeyCombo | undefined> = {
   playPause: c("Space"),
   nextTrack: c("ArrowRight", { mod: true }),
   prevTrack: c("ArrowLeft", { mod: true }),

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -230,8 +230,10 @@ export function migrateBindingsV1ToV2(
     }
     const previousDefault = V1_DEFAULTS[action.id];
     const raw = action.id in v1 ? v1[action.id] : undefined;
-    // Anything that is not a well-formed combo counts as "not customised".
-    const stored = raw === null || isKeyCombo(raw) ? raw : undefined;
+    // Anything that is not a well-formed combo, or that claims a key no action
+    // may hold, counts as "not customised".
+    const stored =
+      raw === null || (isKeyCombo(raw) && !isReserved(raw)) ? raw : undefined;
     if (
       stored !== undefined &&
       previousDefault &&

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -190,32 +190,46 @@ const V1_DEFAULTS: Partial<Record<ActionId, KeyCombo>> = {
   toggleShortcuts: c("Slash", { shift: true }),
 };
 
+function isKeyCombo(value: unknown): value is KeyCombo {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.code === "string" &&
+    typeof v.mod === "boolean" &&
+    typeof v.shift === "boolean" &&
+    typeof v.alt === "boolean"
+  );
+}
+
 export function migrateBindingsV1ToV2(
   v1Raw: string | null,
 ): Record<ActionId, KeyCombo | null> | null {
   if (!v1Raw) return null;
 
-  let v1: Record<string, KeyCombo | null>;
+  let v1: Record<string, unknown>;
   try {
     const parsed: unknown = JSON.parse(v1Raw);
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
       return null;
     }
-    v1 = parsed as Record<string, KeyCombo | null>;
+    v1 = parsed as Record<string, unknown>;
   } catch {
     return null;
   }
 
+  const fixed = new Map<ActionId, KeyCombo>();
   const customised = new Map<ActionId, KeyCombo | null>();
   const fromDefault = new Map<ActionId, KeyCombo | null>();
 
   for (const action of ACTION_REGISTRY) {
     if (action.fixed) {
-      fromDefault.set(action.id, action.default);
+      fixed.set(action.id, action.default);
       continue;
     }
     const previousDefault = V1_DEFAULTS[action.id];
-    const stored = action.id in v1 ? (v1[action.id] ?? null) : undefined;
+    const raw = action.id in v1 ? v1[action.id] : undefined;
+    // Anything that is not a well-formed combo counts as "not customised".
+    const stored = raw === null || isKeyCombo(raw) ? raw : undefined;
     if (
       stored !== undefined &&
       previousDefault &&
@@ -227,21 +241,24 @@ export function migrateBindingsV1ToV2(
     }
   }
 
-  // Customisations claim their combo first; a new default that collides with one
-  // is dropped rather than silently stealing the user's key.
+  // Fixed actions claim their combo first since they can never be rebound, then
+  // customisations; a later claim on a taken combo is dropped rather than
+  // duplicating the binding.
   const result = {} as Record<ActionId, KeyCombo | null>;
   const claimed = new Set<string>();
-  for (const [id, combo] of customised) {
+  for (const [id, combo] of fixed) {
     result[id] = combo;
-    if (combo) claimed.add(comboKey(combo));
+    claimed.add(comboKey(combo));
   }
-  for (const [id, combo] of fromDefault) {
-    if (combo && claimed.has(comboKey(combo))) {
-      result[id] = null;
-      continue;
+  for (const source of [customised, fromDefault]) {
+    for (const [id, combo] of source) {
+      if (combo && claimed.has(comboKey(combo))) {
+        result[id] = null;
+        continue;
+      }
+      result[id] = combo;
+      if (combo) claimed.add(comboKey(combo));
     }
-    result[id] = combo;
-    if (combo) claimed.add(comboKey(combo));
   }
   return result;
 }

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -149,6 +149,7 @@ export const DEFAULT_BINDINGS: Record<ActionId, KeyCombo | null> =
 const RESERVED_COMBOS: readonly KeyCombo[] = [
   c("KeyR", { mod: true }),
   ...ACTION_REGISTRY.filter((a) => a.fixed).map((a) => a.default),
+  ...FIXED_KEY_DOCS.map((d) => d.combo),
 ];
 
 export function comboKey(combo: KeyCombo | null): string {

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -8,6 +8,8 @@ export const ACTION_IDS = [
   "volumeDown",
   "muteToggle",
   "likeToggle",
+  "toggleShuffle",
+  "toggleRepeat",
   "focusSearch",
   "refreshData",
   "closeDrawer",
@@ -33,6 +35,9 @@ type ActionMeta = {
   label: string;
   default: KeyCombo;
   repeatable?: boolean;
+  // Not user-rebindable: always dispatched on `default`, shown read-only in the
+  // shortcuts panel, and its combo is reserved against other actions.
+  fixed?: boolean;
 };
 
 const c = (
@@ -59,8 +64,12 @@ export const ACTION_REGISTRY: readonly ActionMeta[] = [
     default: c("ArrowLeft", { mod: true }),
     repeatable: false,
   },
-  { id: "volumeUp", label: "Volume up", default: c("ArrowUp") },
-  { id: "volumeDown", label: "Volume down", default: c("ArrowDown") },
+  { id: "volumeUp", label: "Volume up", default: c("ArrowUp", { mod: true }) },
+  {
+    id: "volumeDown",
+    label: "Volume down",
+    default: c("ArrowDown", { mod: true }),
+  },
   {
     id: "muteToggle",
     label: "Mute / Unmute",
@@ -74,14 +83,27 @@ export const ACTION_REGISTRY: readonly ActionMeta[] = [
     repeatable: false,
   },
   {
+    id: "toggleShuffle",
+    label: "Shuffle on / off",
+    default: c("KeyS", { alt: true }),
+    repeatable: false,
+  },
+  {
+    id: "toggleRepeat",
+    label: "Repeat off / all / one",
+    default: c("KeyR", { alt: true }),
+    repeatable: false,
+  },
+  {
     id: "focusSearch",
     label: "Focus search bar",
-    default: c("KeyS", { mod: true }),
+    default: c("KeyK", { mod: true }),
   },
   {
     id: "refreshData",
     label: "Refresh app data",
     default: c("KeyR", { mod: true, shift: true }),
+    fixed: true,
   },
   {
     id: "closeDrawer",
@@ -124,12 +146,10 @@ export const DEFAULT_BINDINGS: Record<ActionId, KeyCombo | null> =
     KeyCombo | null
   >;
 
-const RESERVED_COMBOS: readonly KeyCombo[] = [c("KeyR", { mod: true })];
-
-export const shortcutsAtom = atomWithStorage<Record<ActionId, KeyCombo | null>>(
-  "sone.shortcuts.v1",
-  DEFAULT_BINDINGS,
-);
+const RESERVED_COMBOS: readonly KeyCombo[] = [
+  c("KeyR", { mod: true }),
+  ...ACTION_REGISTRY.filter((a) => a.fixed).map((a) => a.default),
+];
 
 export function comboKey(combo: KeyCombo | null): string {
   if (!combo) return "";
@@ -145,6 +165,106 @@ export function comboEquals(a: KeyCombo | null, b: KeyCombo | null): boolean {
     a.alt === b.alt
   );
 }
+
+const STORAGE_KEY_V1 = "sone.shortcuts.v1";
+const STORAGE_KEY_V2 = "sone.shortcuts.v2";
+
+// Frozen snapshot of the v1 defaults. Used only to tell "user customised this"
+// apart from "user never touched this" when migrating.
+const V1_DEFAULTS: Partial<Record<ActionId, KeyCombo>> = {
+  playPause: c("Space"),
+  nextTrack: c("ArrowRight", { mod: true }),
+  prevTrack: c("ArrowLeft", { mod: true }),
+  volumeUp: c("ArrowUp"),
+  volumeDown: c("ArrowDown"),
+  muteToggle: c("KeyM"),
+  likeToggle: c("KeyL"),
+  focusSearch: c("KeyS", { mod: true }),
+  refreshData: c("KeyR", { mod: true, shift: true }),
+  closeDrawer: c("Escape"),
+  zoomIn: c("Equal", { mod: true }),
+  zoomOut: c("Minus", { mod: true }),
+  zoomReset: c("Digit0", { mod: true }),
+  toggleExclusive: c("KeyE", { mod: true }),
+  toggleBitPerfect: c("KeyB", { mod: true }),
+  toggleShortcuts: c("Slash", { shift: true }),
+};
+
+export function migrateBindingsV1ToV2(
+  v1Raw: string | null,
+): Record<ActionId, KeyCombo | null> | null {
+  if (!v1Raw) return null;
+
+  let v1: Record<string, KeyCombo | null>;
+  try {
+    const parsed: unknown = JSON.parse(v1Raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+    v1 = parsed as Record<string, KeyCombo | null>;
+  } catch {
+    return null;
+  }
+
+  const customised = new Map<ActionId, KeyCombo | null>();
+  const fromDefault = new Map<ActionId, KeyCombo | null>();
+
+  for (const action of ACTION_REGISTRY) {
+    if (action.fixed) {
+      fromDefault.set(action.id, action.default);
+      continue;
+    }
+    const previousDefault = V1_DEFAULTS[action.id];
+    const stored = action.id in v1 ? (v1[action.id] ?? null) : undefined;
+    if (
+      stored !== undefined &&
+      previousDefault &&
+      !comboEquals(stored, previousDefault)
+    ) {
+      customised.set(action.id, stored);
+    } else {
+      fromDefault.set(action.id, action.default);
+    }
+  }
+
+  // Customisations claim their combo first; a new default that collides with one
+  // is dropped rather than silently stealing the user's key.
+  const result = {} as Record<ActionId, KeyCombo | null>;
+  const claimed = new Set<string>();
+  for (const [id, combo] of customised) {
+    result[id] = combo;
+    if (combo) claimed.add(comboKey(combo));
+  }
+  for (const [id, combo] of fromDefault) {
+    if (combo && claimed.has(comboKey(combo))) {
+      result[id] = null;
+      continue;
+    }
+    result[id] = combo;
+    if (combo) claimed.add(comboKey(combo));
+  }
+  return result;
+}
+
+function initBindingsStorage(): void {
+  try {
+    if (localStorage.getItem(STORAGE_KEY_V2) !== null) return;
+    const migrated = migrateBindingsV1ToV2(
+      localStorage.getItem(STORAGE_KEY_V1),
+    );
+    if (!migrated) return;
+    localStorage.setItem(STORAGE_KEY_V2, JSON.stringify(migrated));
+  } catch {
+    // Storage unavailable — fall through to defaults.
+  }
+}
+
+initBindingsStorage();
+
+export const shortcutsAtom = atomWithStorage<Record<ActionId, KeyCombo | null>>(
+  STORAGE_KEY_V2,
+  DEFAULT_BINDINGS,
+);
 
 export function isReserved(combo: KeyCombo): boolean {
   return RESERVED_COMBOS.some((r) => comboEquals(r, combo));


### PR DESCRIPTION
Fixes the keyboard half of #189.

## Bugs / Problems

- Bare arrow keys changed the volume app-wide and swallowed the keypress, so nothing could be scrolled from the keyboard. Volume moves to `Ctrl+↑` / `Ctrl+↓`.
- Freeing the arrows was not enough on its own: the main scroll container was never focusable, so arrows did nothing at all until you first clicked the page. It now takes focus on navigation.
- `Ctrl+S` was bound to search — the Save key in every other desktop app, and Shuffle in most players. Search moves to `Ctrl+K`, and shuffle and repeat gain `Alt+S` / `Alt+R`, which had no shortcuts at all before.
- `Ctrl+Shift+R` cleared only the in-memory cache, while Settings → Utilities → "Refresh App" also cleared the backend disk cache. Same label, different behaviour; both now go through one path, so they cannot drift again.
- `Escape` dismissed several layers at once. Fourteen independent listeners coordinating through ad-hoc guards meant a context menu opened over the now-playing drawer closed both at a single press. One priority-ordered stack now closes exactly one layer, and owns the key outright.
- Changing the defaults alone would have reached nobody, since stored bindings win over them. A one-shot migration adopts the new defaults while preserving anything a user had customised, and keys the dismissal stack owns can no longer be bound to an action.
