### PR TITLE
perf(ui): keep the loved banner's blobs composited so their blur is d…

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -208,87 +208,220 @@ svg[stroke-width="3"] {
   animation: barBounce 1s ease-in-out infinite;
 }
 
-/* Loved Tracks "Living Heart" banner — drifting heart-colored blobs */
+/* Loved Tracks "Living Heart" banner — drifting heart-colored blobs.
+   Softness is a painted gradient, not filter: blur() — a filter is re-applied by
+   the compositor every frame, a gradient is rasterized once. Each blob runs drift,
+   morph and pulse on non-harmonic periods, so the combined path takes hours to
+   repeat while staying on transform/opacity only. */
 .loved-blob {
   position: absolute;
-  border-radius: 9999px;
-  filter: blur(55px);
   will-change: transform;
+  animation-timing-function: ease-in-out;
+}
+.loved-blob-inner {
+  position: absolute;
+  inset: 0;
+  will-change: transform, opacity;
+  animation-timing-function: ease-in-out;
 }
 .loved-blob-1 {
-  width: 55%;
-  height: 150%;
-  left: -5%;
-  top: -30%;
-  background: #450af5;
+  width: 79.75%;
+  height: 232.5%;
+  left: -17.38%;
+  top: -71.25%;
+  animation: lovedDrift1 23s ease-in-out -4s infinite;
+}
+.loved-blob-1 .loved-blob-inner {
+  background: radial-gradient(
+    closest-side,
+    #450af5 0%,
+    rgba(69, 10, 245, 0.98) 46%,
+    rgba(69, 10, 245, 0.84) 60%,
+    rgba(69, 10, 245, 0.5) 73%,
+    rgba(69, 10, 245, 0.16) 86%,
+    rgba(69, 10, 245, 0) 100%
+  );
   opacity: 0.85;
-  animation: lovedDrift1 12s ease-in-out infinite;
+  animation:
+    lovedMorph1 19s ease-in-out -7s infinite,
+    lovedPulse1 31s ease-in-out -11s infinite;
 }
 .loved-blob-2 {
-  width: 50%;
-  height: 140%;
-  left: 25%;
-  top: -10%;
-  background: #8e2de2;
+  width: 72.5%;
+  height: 217%;
+  left: 13.75%;
+  top: -48.5%;
+  animation: lovedDrift2 29s ease-in-out -9s infinite;
+}
+.loved-blob-2 .loved-blob-inner {
+  background: radial-gradient(
+    closest-side,
+    #8e2de2 0%,
+    rgba(142, 45, 226, 0.98) 46%,
+    rgba(142, 45, 226, 0.84) 60%,
+    rgba(142, 45, 226, 0.5) 73%,
+    rgba(142, 45, 226, 0.16) 86%,
+    rgba(142, 45, 226, 0) 100%
+  );
   opacity: 0.85;
-  animation: lovedDrift2 15s ease-in-out infinite;
+  animation:
+    lovedMorph2 17s ease-in-out -2s infinite,
+    lovedPulse2 37s ease-in-out -19s infinite;
 }
 .loved-blob-3 {
-  width: 45%;
-  height: 130%;
-  left: 50%;
-  top: -20%;
-  background: #00d2ff;
-  opacity: 0.6;
-  animation: lovedDrift3 13s ease-in-out infinite;
+  width: 65.25%;
+  height: 201.5%;
+  left: 39.88%;
+  top: -55.75%;
+  animation: lovedDrift3 26s ease-in-out -15s infinite;
 }
-
+.loved-blob-3 .loved-blob-inner {
+  background: radial-gradient(
+    closest-side,
+    #00d2ff 0%,
+    rgba(0, 210, 255, 0.98) 46%,
+    rgba(0, 210, 255, 0.84) 60%,
+    rgba(0, 210, 255, 0.5) 73%,
+    rgba(0, 210, 255, 0.16) 86%,
+    rgba(0, 210, 255, 0) 100%
+  );
+  opacity: 0.6;
+  animation:
+    lovedMorph3 21s ease-in-out -5s infinite,
+    lovedPulse3 41s ease-in-out -6s infinite;
+}
 @keyframes lovedDrift1 {
   0% {
-    transform: translate3d(0, 0, 0);
+    transform: translate3d(0%, 0%, 0);
   }
-  33% {
-    transform: translate3d(26%, 12%, 0);
+  28% {
+    transform: translate3d(15.2%, 6.1%, 0);
   }
-  66% {
-    transform: translate3d(12%, -10%, 0);
+  52% {
+    transform: translate3d(4.3%, -7.4%, 0);
+  }
+  76% {
+    transform: translate3d(-9.6%, 3.8%, 0);
   }
   100% {
-    transform: translate3d(0, 0, 0);
+    transform: translate3d(0%, 0%, 0);
   }
 }
 @keyframes lovedDrift2 {
   0% {
-    transform: translate3d(0, 0, 0);
+    transform: translate3d(0%, 0%, 0);
   }
-  50% {
-    transform: translate3d(-30%, 14%, 0);
+  31% {
+    transform: translate3d(-17.4%, 7.9%, 0);
+  }
+  58% {
+    transform: translate3d(-6.1%, -5.2%, 0);
+  }
+  81% {
+    transform: translate3d(9.8%, 4.4%, 0);
   }
   100% {
-    transform: translate3d(0, 0, 0);
+    transform: translate3d(0%, 0%, 0);
   }
 }
 @keyframes lovedDrift3 {
   0% {
-    transform: translate3d(0, 0, 0);
+    transform: translate3d(0%, 0%, 0);
   }
-  40% {
-    transform: translate3d(-22%, -14%, 0);
+  24% {
+    transform: translate3d(-12.7%, -8.1%, 0);
   }
-  80% {
-    transform: translate3d(20%, 10%, 0);
+  49% {
+    transform: translate3d(6.4%, 5.6%, 0);
+  }
+  73% {
+    transform: translate3d(13.1%, -3.3%, 0);
   }
   100% {
-    transform: translate3d(0, 0, 0);
+    transform: translate3d(0%, 0%, 0);
+  }
+}
+@keyframes lovedMorph1 {
+  0% {
+    transform: rotate(0deg) scale(1);
+  }
+  37% {
+    transform: rotate(6deg) scale(1.14);
+  }
+  68% {
+    transform: rotate(-4deg) scale(0.94);
+  }
+  100% {
+    transform: rotate(0deg) scale(1);
+  }
+}
+@keyframes lovedMorph2 {
+  0% {
+    transform: rotate(0deg) scale(1);
+  }
+  44% {
+    transform: rotate(-9deg) scale(1.19);
+  }
+  79% {
+    transform: rotate(5deg) scale(0.96);
+  }
+  100% {
+    transform: rotate(0deg) scale(1);
+  }
+}
+@keyframes lovedMorph3 {
+  0% {
+    transform: rotate(0deg) scale(1);
+  }
+  41% {
+    transform: rotate(7deg) scale(1.11);
+  }
+  72% {
+    transform: rotate(-6deg) scale(0.9);
+  }
+  100% {
+    transform: rotate(0deg) scale(1);
+  }
+}
+@keyframes lovedPulse1 {
+  0%,
+  100% {
+    opacity: 0.85;
+  }
+  46% {
+    opacity: 0.58;
+  }
+}
+@keyframes lovedPulse2 {
+  0%,
+  100% {
+    opacity: 0.85;
+  }
+  53% {
+    opacity: 0.6;
+  }
+}
+@keyframes lovedPulse3 {
+  0%,
+  100% {
+    opacity: 0.6;
+  }
+  48% {
+    opacity: 0.38;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .loved-blob-1,
-  .loved-blob-2,
-  .loved-blob-3 {
+  .loved-blob,
+  .loved-blob-inner {
     animation: none;
   }
+}
+
+/* Toggled from main.tsx when the OS window loses focus. */
+.window-unfocused .loved-blob,
+.window-unfocused .loved-blob-inner {
+  animation-play-state: paused;
 }
 
 /* Adaptive card scroll — cards fill container exactly, scroll-snap for paging */

--- a/src/App.css
+++ b/src/App.css
@@ -226,41 +226,41 @@ textarea {
 
 @keyframes lovedDrift1 {
   0% {
-    transform: translate3d(0, 0, 0) scale(1);
+    transform: translate3d(0, 0, 0);
   }
   33% {
-    transform: translate3d(26%, 12%, 0) scale(1.18);
+    transform: translate3d(26%, 12%, 0);
   }
   66% {
-    transform: translate3d(12%, -10%, 0) scale(0.92);
+    transform: translate3d(12%, -10%, 0);
   }
   100% {
-    transform: translate3d(0, 0, 0) scale(1);
+    transform: translate3d(0, 0, 0);
   }
 }
 @keyframes lovedDrift2 {
   0% {
-    transform: translate3d(0, 0, 0) scale(1);
+    transform: translate3d(0, 0, 0);
   }
   50% {
-    transform: translate3d(-30%, 14%, 0) scale(1.22);
+    transform: translate3d(-30%, 14%, 0);
   }
   100% {
-    transform: translate3d(0, 0, 0) scale(1);
+    transform: translate3d(0, 0, 0);
   }
 }
 @keyframes lovedDrift3 {
   0% {
-    transform: translate3d(0, 0, 0) scale(1);
+    transform: translate3d(0, 0, 0);
   }
   40% {
-    transform: translate3d(-22%, -14%, 0) scale(1.12);
+    transform: translate3d(-22%, -14%, 0);
   }
   80% {
-    transform: translate3d(20%, 10%, 0) scale(0.9);
+    transform: translate3d(20%, 10%, 0);
   }
   100% {
-    transform: translate3d(0, 0, 0) scale(1);
+    transform: translate3d(0, 0, 0);
   }
 }
 

--- a/src/components/LovedTracksBanner.tsx
+++ b/src/components/LovedTracksBanner.tsx
@@ -2,14 +2,9 @@
 // blobs in the signature heart colors drift slowly behind the header, mirroring
 // CoverBanner's overlay structure so it sits consistently with the other pages.
 
-const FADE = "linear-gradient(to bottom, #000 0%, #000 70%, transparent 100%)";
-
 export default function LovedTracksBanner() {
   return (
-    <div
-      className="pointer-events-none absolute inset-0 overflow-hidden select-none"
-      style={{ maskImage: FADE, WebkitMaskImage: FADE }}
-    >
+    <div className="pointer-events-none absolute inset-0 overflow-hidden select-none">
       <div className="loved-blob loved-blob-1" />
       <div className="loved-blob loved-blob-2" />
       <div className="loved-blob loved-blob-3" />
@@ -17,6 +12,7 @@ export default function LovedTracksBanner() {
       <div className="absolute inset-0 bg-th-base/60" />
       {/* Settle the right edge into the page tone, like CoverBanner. */}
       <div className="absolute inset-0 bg-gradient-to-r from-transparent via-th-base/20 to-th-base/60" />
+      <div className="absolute inset-0 bg-gradient-to-b from-transparent from-70% to-th-surface" />
     </div>
   );
 }

--- a/src/components/LovedTracksBanner.tsx
+++ b/src/components/LovedTracksBanner.tsx
@@ -1,13 +1,19 @@
-// Animated "Living Heart" backdrop for the Loved Tracks header. Three blurred
-// blobs in the signature heart colors drift slowly behind the header, mirroring
-// CoverBanner's overlay structure so it sits consistently with the other pages.
+// Animated "Living Heart" backdrop for the Loved Tracks header. Three soft
+// gradient blobs in the signature heart colors drift slowly behind the header,
+// mirroring CoverBanner's overlay structure so it sits consistently with other pages.
 
 export default function LovedTracksBanner() {
   return (
     <div className="pointer-events-none absolute inset-0 overflow-hidden select-none">
-      <div className="loved-blob loved-blob-1" />
-      <div className="loved-blob loved-blob-2" />
-      <div className="loved-blob loved-blob-3" />
+      <div className="loved-blob loved-blob-1">
+        <div className="loved-blob-inner" />
+      </div>
+      <div className="loved-blob loved-blob-2">
+        <div className="loved-blob-inner" />
+      </div>
+      <div className="loved-blob loved-blob-3">
+        <div className="loved-blob-inner" />
+      </div>
       {/* Base-tone overlay: keeps the title readable on light or dark themes. */}
       <div className="absolute inset-0 bg-th-base/60" />
       {/* Settle the right edge into the page tone, like CoverBanner. */}

--- a/src/lib/windowFocus.ts
+++ b/src/lib/windowFocus.ts
@@ -1,0 +1,16 @@
+/**
+ * Flags the document while the OS window is in the background so purely
+ * decorative animations can pause instead of compositing frames nobody sees.
+ */
+export function trackWindowFocus(): void {
+  const apply = () => {
+    const active =
+      document.visibilityState === "visible" && document.hasFocus();
+    document.documentElement.classList.toggle("window-unfocused", !active);
+  };
+
+  window.addEventListener("focus", apply);
+  window.addEventListener("blur", apply);
+  document.addEventListener("visibilitychange", apply);
+  apply();
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import { bootstrapThemeFile } from "./lib/themeFile";
+import { trackWindowFocus } from "./lib/windowFocus";
 
 /**
  * Resolve the external theme file (~/.config/sone/theme.json) BEFORE the
@@ -10,6 +11,7 @@ import { bootstrapThemeFile } from "./lib/themeFile";
  * Also in promise so a stuck IPC cannot block startup.
  */
 async function main() {
+  trackWindowFocus();
   await Promise.race([
     bootstrapThemeFile(),
     new Promise<void>((resolve) => setTimeout(resolve, 2000)),


### PR DESCRIPTION
Loved Tracks loads 100% CPU while idle. The banner's mask-image kept three blobs off the compositor, so every drift frame repainted the subtree and redid all three blur(55px) on the CPU. scale() in the keyframes forced the same re-raster.

Closes the main issue of [https://github.com/lullabyX/sone/issues/191](https://github.com/lullabyX/sone/issues/191)