### PR TITLE
perf(ui): rasterize the blurred cover banner once instead of on every…

### DIFF
--- a/src/components/CoverBanner.tsx
+++ b/src/components/CoverBanner.tsx
@@ -32,7 +32,12 @@ export default function CoverBanner({
   return (
     <div
       className="pointer-events-none absolute inset-0 overflow-hidden select-none"
-      style={{ maskImage: fade, WebkitMaskImage: fade }}
+      style={{
+        maskImage: fade,
+        WebkitMaskImage: fade,
+        // Own layer, so the blur rasterizes once instead of on every scroll repaint.
+        ...(variant === "blur" ? { willChange: "transform" } : null),
+      }}
     >
       {variant === "blur" ? (
         <>


### PR DESCRIPTION
The blurred cover banner on the playlist and mix pages had no compositing layer of its own, so WebKit recomputed filter: blur(48px) every time the scroll layer repainted. will-change: transform makes it rasterize once and just move afterwards.

Partially fixes [https://github.com/lullabyX/sone/issues/150](https://github.com/lullabyX/sone/issues/150)