### PR TITLE
[#206] feat: Theme config now saved in local file

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,13 +425,22 @@ This is a known issue with NVIDIA's proprietary drivers and WebKitGTK hardware a
 
 ## Custom theme file
 
-The theme presets/custom colors are stored at:
+The theme presets/custom colors are stored in `theme.json`, inside SONE's config
+directory. **That directory depends on how you installed SONE**, because Flatpak
+and Snap both redirect `XDG_CONFIG_HOME` into their own sandbox:
 
-```
-~/.config/sone/theme.json
-```
+| Install | `theme.json` |
+| --- | --- |
+| Native (AUR, `.deb`, `.rpm`, AppImage) | `~/.config/sone/theme.json` |
+| Flatpak | `~/.var/app/io.github.lullabyX.sone/config/sone/theme.json` |
+| Snap | `~/snap/sone/current/.config/sone/theme.json` |
 
-SONE picks it up **at startup and whenever the window is displayed** (e.g. restoring from the tray).
+A sandboxed SONE cannot read `~/.config/sone/`, so tools that write the theme
+for you need the matching path above.
+
+SONE reads the file **at startup, and whenever the window regains focus**. A
+change made while SONE is unfocused or in the tray is applied the next time you
+focus the window, not immediately.
 
 ```json
 {
@@ -444,10 +453,17 @@ SONE picks it up **at startup and whenever the window is displayed** (e.g. resto
 }
 ```
 
-- `preset` = values can be `"custom"` or one of the built-in preset names (e.g. `"Ocean"`, `"Forest"`, `"Noir"`), case-sensitive.
+- `preset` = `"custom"`, or one of the built-in preset names (e.g. `"Ocean"`, `"Forest"`, `"Noir"`), case-sensitive.
 - `custom.accent` / `custom.background` = `#RGB` or `#RRGGBB` colors.
+- Both keys are required, even when `preset` names a built-in — `{"preset": "Ocean"}` on its own is rejected.
+- Strict JSON only: comments and trailing commas are not accepted.
 
-Invalid files are ignored, the in-app config in localStorage wins.
+When `preset` names a built-in, that preset's colors win and `custom` is ignored
+for display. SONE rewrites `custom` to match the preset the next time you change
+the theme in Settings.
+
+A file SONE cannot parse is left alone and the in-app theme is kept. Fix the
+file and restart, or change the theme in Settings to overwrite it.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -423,6 +423,32 @@ This is a known issue with NVIDIA's proprietary drivers and WebKitGTK hardware a
 
 </details>
 
+## Custom theme file
+
+The theme presets/custom colors are stored at:
+
+```
+~/.config/sone/theme.json
+```
+
+SONE picks it up **at startup and whenever the window is displayed** (e.g. restoring from the tray).
+
+```json
+{
+    "version": 1,
+    "preset": "custom",
+    "custom": {
+        "accent": "#3B82F6",
+        "background": "#0E1118"
+    }
+}
+```
+
+- `preset` = values can be `"custom"` or one of the built-in preset names (e.g. `"Ocean"`, `"Forest"`, `"Noir"`), case-sensitive.
+- `custom.accent` / `custom.background` = `#RGB` or `#RRGGBB` colors.
+
+Invalid files are ignored, the in-app config in localStorage wins.
+
 ## FAQ
 
 <details>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ mod rate_gate;
 mod scrobble;
 mod signal_path;
 mod pipeline_probe;
+mod theme_config;
 #[cfg(target_os = "linux")]
 mod tray;
 mod tidal_api;
@@ -767,7 +768,7 @@ pub fn run() {
                         })
                         .ok();
                 }
-                
+
                 // tauri.conf.json sets decorations: false, so the window is
                 // born without GTK CSD. Only re-enable native chrome if the
                 // user has explicitly opted in via the escape-hatch toggle.
@@ -863,6 +864,9 @@ pub fn run() {
             }
         })
         .invoke_handler(tauri::generate_handler![
+            // theme file
+            theme_config::theme_file_get,
+            theme_config::theme_file_set,
             // auth
             commands::auth::greet,
             commands::auth::load_saved_auth,

--- a/src-tauri/src/theme_config.rs
+++ b/src-tauri/src/theme_config.rs
@@ -1,0 +1,364 @@
+//! External theme configuration — `<config_sone_dir>/theme.json`.
+//!
+//! File shape:
+//! ```json
+//! {
+//!     "version": 1,
+//!     "preset": "custom",
+//!     "custom": { "accent": "#3B82F6", "background": "#0E1118" }
+//! }
+//! ```
+
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+/// Current schema version.
+pub const THEME_FILE_VERSION: u32 = 1;
+
+/// The `"preset"` meaning "use the `custom` colors".
+pub const CUSTOM_PRESET: &str = "custom";
+
+/// Canonical preset names. Must stay in sync with `PRESET_THEMES`
+/// in `src/lib/theme.ts`(case-sensitive, order irrelevant).
+pub const PRESET_NAMES: &[&str] = &[
+    "Violet Night",
+    "Cyberpunk",
+    "Forest",
+    "Ocean",
+    "Midnight Cyan",
+    "Sakura",
+    "Rose",
+    "Ember",
+    "Copper",
+    "Noir",
+    "Daylight",
+    "Snowfall",
+    "Paper",
+    "Meadow",
+    "Blossom",
+];
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+pub struct ThemeFile {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<u32>,
+    pub preset: String,
+    pub custom: ThemeCustom,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+pub struct ThemeCustom {
+    pub accent: String,
+    pub background: String,
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+/// Validate a hex color and normalize it to uppercase `#RRGGBB`.
+fn normalize_hex(input: &str) -> Option<String> {
+    let digits = input.trim().strip_prefix('#')?;
+    let bytes: Vec<u8> = if digits.len() == 3 {
+        digits.bytes().flat_map(|b| [b, b]).collect()
+    } else if digits.len() == 6 {
+        digits.bytes().collect()
+    } else {
+        return None;
+    };
+    let mut out = String::with_capacity(7);
+    out.push('#');
+    for b in bytes {
+        if !b.is_ascii_hexdigit() {
+            return None;
+        }
+        let c = (b as char).to_ascii_uppercase();
+        out.push(c);
+    }
+    Some(out)
+}
+
+pub fn validate(raw: &ThemeFile) -> Result<ThemeFile, String> {
+    if let Some(v) = raw.version {
+        if v != THEME_FILE_VERSION {
+            return Err(format!(
+                "unknown theme file version {v} (expected {THEME_FILE_VERSION})"
+            ));
+        }
+    }
+
+    // Is preset known
+    if raw.preset != CUSTOM_PRESET && !PRESET_NAMES.contains(&raw.preset.as_str()) {
+        return Err(format!("unknown theme preset {:?}", raw.preset));
+    }
+
+    let accent = normalize_hex(&raw.custom.accent)
+        .ok_or_else(|| format!("invalid accent color {:?}", raw.custom.accent))?;
+    let background = normalize_hex(&raw.custom.background)
+        .ok_or_else(|| format!("invalid background color {:?}", raw.custom.background))?;
+
+    Ok(ThemeFile {
+        version: Some(THEME_FILE_VERSION),
+        preset: raw.preset.clone(),
+        custom: ThemeCustom { accent, background },
+    })
+}
+
+// ---------------------------------------------------------------------------
+// File I/O
+// ---------------------------------------------------------------------------
+
+fn config_sone_dir() -> Result<PathBuf, String> {
+    let dir = dirs::config_dir()
+        .ok_or_else(|| "config directory is unresolvable".to_string())?
+        .join("sone");
+    fs::create_dir_all(&dir).map_err(|e| format!("failed to create {dir:?}: {e}"))?;
+    Ok(dir)
+}
+
+/// Read + validate the theme file.
+///
+/// - File absent            -> `Ok(None)`
+/// - File present + valid   -> `Ok(Some(normalized))`
+/// - File present + invalid -> `Err`
+pub fn read_theme_file(path: &Path) -> Result<Option<ThemeFile>, String> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw = fs::read_to_string(path).map_err(|e| format!("failed to read {path:?}: {e}"))?;
+    let parsed: ThemeFile =
+        serde_json::from_str(&raw).map_err(|e| format!("theme file is not valid JSON: {e}"))?;
+    match validate(&parsed) {
+        Ok(normalized) => Ok(Some(normalized)),
+        Err(e) => {
+            log::warn!("theme: ignoring invalid {path:?}: {e}");
+            Err(e)
+        }
+    }
+}
+
+/// Validate and atomically write the theme file (`tmp-<pid>` -> fsync ->
+/// rename), mode `0644`. So a crash can never leave a torn file.
+pub fn write_theme_file(path: &Path, file: &ThemeFile) -> Result<(), String> {
+    let normalized = validate(file)?;
+    let json = serde_json::to_string_pretty(&normalized)
+        .map_err(|e| format!("failed to serialize theme: {e}"))?;
+
+    let parent = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent).map_err(|e| format!("failed to create {:?}: {e}", parent))?;
+
+    let tmp = parent.join(format!(
+        "{}.tmp-{}",
+        path.file_name().ok_or("bad path")?.to_string_lossy(),
+        std::process::id()
+    ));
+
+    let mut opts = fs::OpenOptions::new();
+    opts.create(true).truncate(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o644);
+    }
+    // Write temp file, ensure data is written on disk.
+    let mut f = opts
+        .open(&tmp)
+        .map_err(|e| format!("failed to open {tmp:?}: {e}"))?;
+    f.write_all(json.as_bytes())
+        .map_err(|e| format!("failed to write {tmp:?}: {e}"))?;
+    f.flush()
+        .map_err(|e| format!("failed to flush {tmp:?}: {e}"))?;
+    f.sync_all()
+        .map_err(|e| format!("failed to fsync {tmp:?}: {e}"))?;
+    drop(f);
+
+    // Rename to correct path, replaces original file if 'to' already exists.
+    fs::rename(&tmp, path).map_err(|e| {
+        let _ = fs::remove_file(&tmp);
+        format!("failed to rename {tmp:?} → {path:?}: {e}")
+    })?;
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tauri commands
+// ---------------------------------------------------------------------------
+
+#[tauri::command]
+pub fn theme_file_get() -> Result<Option<ThemeFile>, String> {
+    let dir = config_sone_dir()?;
+    read_theme_file(&dir.join("theme.json"))
+}
+
+#[tauri::command]
+pub fn theme_file_set(file: ThemeFile) -> Result<(), String> {
+    let dir = config_sone_dir()?;
+    write_theme_file(&dir.join("theme.json"), &file)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn custom(accent: &str, background: &str) -> ThemeFile {
+        ThemeFile {
+            version: Some(1),
+            preset: "custom".to_string(),
+            custom: ThemeCustom {
+                accent: accent.to_string(),
+                background: background.to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn validate_custom_ok() {
+        let v = validate(&custom("#3b82f6", "#0E1118")).unwrap();
+        assert_eq!(v.preset, "custom");
+        assert_eq!(v.custom.accent, "#3B82F6");
+        assert_eq!(v.custom.background, "#0E1118");
+        assert_eq!(v.version, Some(1));
+    }
+
+    #[test]
+    fn validate_rgb_expanded() {
+        let v = validate(&custom("#fff", "#abc")).unwrap();
+        assert_eq!(v.custom.accent, "#FFFFFF");
+        assert_eq!(v.custom.background, "#AABBCC");
+    }
+
+    #[test]
+    fn validate_named_preset_keeps_preset() {
+        let f = ThemeFile {
+            version: None, // absent version == 1
+            preset: "Ocean".to_string(),
+            // deliberately mismatched colors: preset is authoritative
+            custom: ThemeCustom {
+                accent: "#123456".to_string(),
+                background: "#654321".to_string(),
+            },
+        };
+        let v = validate(&f).unwrap();
+        assert_eq!(v.preset, "Ocean");
+        assert_eq!(v.version, Some(1));
+    }
+
+    #[test]
+    fn validate_unknown_preset_rejected() {
+        let f = ThemeFile {
+            preset: "ocean".to_string(), // case-sensitive
+            ..custom("#3B82F6", "#0E1118")
+        };
+        assert!(validate(&f).is_err());
+        let f = ThemeFile {
+            preset: "Solarized".to_string(),
+            ..custom("#3B82F6", "#0E1118")
+        };
+        assert!(validate(&f).is_err());
+    }
+
+    #[test]
+    fn validate_bad_hex_rejected() {
+        assert!(validate(&custom("#GGG", "#0E1118")).is_err());
+        assert!(validate(&custom("#3B82F", "#0E1118")).is_err());
+        assert!(validate(&custom("3B82F6", "#0E1118")).is_err());
+        assert!(validate(&custom("", "#0E1118")).is_err());
+    }
+
+    #[test]
+    fn validate_unknown_version_rejected() {
+        let f = ThemeFile {
+            version: Some(2),
+            ..custom("#3B82F6", "#0E1118")
+        };
+        assert!(validate(&f).is_err());
+    }
+
+    #[test]
+    fn read_missing_file_is_none() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            read_theme_file(&dir.path().join("theme.json")).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn read_invalid_file_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("theme.json");
+        // garbage bytes
+        fs::write(&p, b"not json at all {{{").unwrap();
+        assert!(read_theme_file(&p).is_err());
+        // unknown version
+        fs::write(
+            &p,
+            r###"{"version": 99, "preset": "custom", "custom": {"accent": "#3B82F6", "background": "#0E1118"}}"###,
+        )
+        .unwrap();
+        assert!(read_theme_file(&p).is_err());
+        // missing custom
+        fs::write(&p, r#"{"preset": "custom"}"#).unwrap();
+        assert!(read_theme_file(&p).is_err());
+    }
+
+    #[test]
+    fn round_trip_and_no_temp_linger() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("theme.json");
+
+        let file = ThemeFile {
+            preset: "Ocean".to_string(),
+            custom: ThemeCustom {
+                accent: "#3b82f6".to_string(),
+                background: "#0e1118".to_string(),
+            },
+            version: None,
+        };
+        write_theme_file(&p, &file).unwrap();
+
+        let read = read_theme_file(&p).unwrap().unwrap();
+        assert_eq!(read, validate(&file).unwrap());
+
+        // Atomic temp file must not linger.
+        let leftover: Vec<String> = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .filter(|n| n.contains(".tmp-"))
+            .collect();
+        assert!(leftover.is_empty());
+    }
+
+    #[test]
+    fn overwrite_replaces_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("theme.json");
+        write_theme_file(&p, &custom("#111111", "#222222")).unwrap();
+        write_theme_file(&p, &custom("#3B82F6", "#0E1118")).unwrap();
+        let read = read_theme_file(&p).unwrap().unwrap();
+        assert_eq!(read.custom.accent, "#3B82F6");
+        assert_eq!(read.custom.background, "#0E1118");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn file_mode_is_0644() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("theme.json");
+        write_theme_file(&p, &custom("#3B82F6", "#0E1118")).unwrap();
+        let mode = fs::metadata(&p).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o644);
+    }
+}

--- a/src/atoms/theme.ts
+++ b/src/atoms/theme.ts
@@ -1,7 +1,7 @@
 import { atomWithStorage } from "jotai/utils";
-import { type Theme, PRESET_THEMES } from "../lib/theme";
+import { type Theme, PRESET_THEMES, THEME_STORAGE_KEY } from "../lib/theme";
 
 export const themeAtom = atomWithStorage<Theme>(
-  "sone.theme.v1",
+  THEME_STORAGE_KEY,
   PRESET_THEMES[0],
 );

--- a/src/components/AppInitializer.tsx
+++ b/src/components/AppInitializer.tsx
@@ -13,6 +13,7 @@ import { useSetAtom, useStore, useAtomValue } from "jotai";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrent, onOpenUrl } from "@tauri-apps/plugin-deep-link";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { parseTidalUrl } from "../lib/tidalUrl";
 import { updateToastSeenAtom } from "../atoms/updates";
@@ -67,7 +68,9 @@ import {
   drawerOpenAtom,
   maximizedPlayerAtom,
 } from "../atoms/ui";
+import { themeAtom } from "../atoms/theme";
 import { proxySettingsAtom, type ProxySettings } from "../atoms/proxy";
+import { syncThemeToFile, handleThemeFocusChange } from "../lib/themeFile";
 
 // Stable action callbacks (no atom subscriptions)
 import { usePlaybackActions } from "../hooks/usePlaybackActions";
@@ -765,6 +768,45 @@ export function AppInitializer() {
         );
       }
     };
+  }, [store]);
+
+  // ================================================================
+  //  THEME FILE WRITE-THROUGH — persist themeAtom ->
+  //  CONFIG_SONE_DIR/theme.json
+  // ================================================================
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const unsub = store.sub(themeAtom, () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        timer = null;
+        void syncThemeToFile(store.get(themeAtom));
+      }, 150);
+    });
+    return () => {
+      unsub();
+      if (timer) clearTimeout(timer);
+    };
+  }, [store]);
+
+  // ================================================================
+  //  EXTERNAL THEME FILE — re-read when window is displayed
+  //  (tray/taskbar restore, re-focus)
+  // ================================================================
+  useEffect(() => {
+    let unlisten: (() => void) | null = null;
+    getCurrentWindow()
+      .onFocusChanged(({ payload: focused }) => {
+        void handleThemeFocusChange(
+          focused,
+          () => store.get(themeAtom),
+          (t) => store.set(themeAtom, t),
+        );
+      })
+      .then((fn) => {
+        unlisten = fn;
+      });
+    return () => unlisten?.();
   }, [store]);
 
   // ================================================================

--- a/src/hooks/useMiniplayerEmitter.ts
+++ b/src/hooks/useMiniplayerEmitter.ts
@@ -12,6 +12,7 @@ import {
 } from "../atoms/playback";
 import { favoriteTrackIdsAtom } from "../atoms/favorites";
 import { miniplayerOpenAtom } from "../atoms/ui";
+import { themeAtom } from "../atoms/theme";
 import { getInterpolatedPosition } from "../lib/playbackPosition";
 import { usePlaybackActions } from "./usePlaybackActions";
 import { useFavorites } from "./useFavorites";
@@ -66,15 +67,8 @@ export function useMiniplayerEmitter() {
     const source =
       store.get(contextSourceAtom) || store.get(playbackSourceAtom);
 
-    // Read accent from theme in localStorage
-    let accentColor = "#A855F7"; // fallback
-    try {
-      const stored = localStorage.getItem("sone.theme.v1");
-      if (stored) {
-        const theme = JSON.parse(stored);
-        if (theme.accent) accentColor = theme.accent;
-      }
-    } catch {}
+    // Read accent from the live theme atom.
+    const accentColor = store.get(themeAtom).accent;
 
     return {
       track: track

--- a/src/lib/theme.test.ts
+++ b/src/lib/theme.test.ts
@@ -40,13 +40,23 @@ describe("themeToFile", () => {
     });
   });
 
-  it("is case-insensitive for preset matching", () => {
+  it("is case-insensitive when matching a preset's colors", () => {
+    const f = themeToFile({
+      name: "Ocean",
+      accent: "#3b82f6",
+      bgBase: "#0e1118",
+    });
+    expect(f.preset).toBe("Ocean");
+    expect(f.custom.accent).toBe("#3B82F6");
+  });
+
+  it("leaves a Custom theme custom even on a preset's exact colors", () => {
     const f = themeToFile({
       name: "Custom",
       accent: "#3b82f6",
       bgBase: "#0e1118",
     });
-    expect(f.preset).toBe("Ocean");
+    expect(f.preset).toBe("custom");
     expect(f.custom.accent).toBe("#3B82F6");
   });
 
@@ -182,5 +192,39 @@ describe("themesEqual", () => {
         { name: "b", accent: "#111111", bgBase: "#000001" },
       ),
     ).toBe(false);
+  });
+});
+
+describe("themeToFile round-trip fidelity", () => {
+  const roundTrip = (f: ThemeFile) => themeToFile(resolveThemeFile(f)!);
+
+  it("keeps preset:'custom' when the colors happen to equal a preset", () => {
+    const file: ThemeFile = {
+      version: 1,
+      preset: "custom",
+      custom: { accent: "#3B82F6", background: "#0E1118" }, // == Ocean
+    };
+    expect(roundTrip(file)).toEqual(file);
+  });
+
+  it("keeps a named preset", () => {
+    const file: ThemeFile = {
+      version: 1,
+      preset: "Forest",
+      custom: { accent: "#22C55E", background: "#0E1410" },
+    };
+    expect(roundTrip(file)).toEqual(file);
+  });
+
+  it("does not trust a theme name whose colors no longer match the preset", () => {
+    // A stale localStorage entry claiming to be Ocean with edited colors is
+    // a custom theme, not Ocean.
+    expect(
+      themeToFile({ name: "Ocean", accent: "#FF00AA", bgBase: "#101010" }),
+    ).toEqual({
+      version: 1,
+      preset: "custom",
+      custom: { accent: "#FF00AA", background: "#101010" },
+    });
   });
 });

--- a/src/lib/theme.test.ts
+++ b/src/lib/theme.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from "vitest";
+import {
+  PRESET_THEMES,
+  normalizeHex,
+  resolveThemeFile,
+  themeToFile,
+  themesEqual,
+  type Theme,
+  type ThemeFile,
+} from "./theme";
+
+const CUSTOM: Theme = { name: "Custom", accent: "#123456", bgBase: "#654321" };
+
+describe("normalizeHex", () => {
+  it("accepts #RRGGBB and uppercases", () => {
+    expect(normalizeHex("#3b82f6")).toBe("#3B82F6");
+  });
+
+  it("expands #RGB", () => {
+    expect(normalizeHex("#fff")).toBe("#FFFFFF");
+    expect(normalizeHex("#a1b")).toBe("#AA11BB");
+  });
+
+  it("rejects malformed input", () => {
+    expect(normalizeHex("3B82F6")).toBeNull();
+    expect(normalizeHex("#3B82F")).toBeNull();
+    expect(normalizeHex("#GGGGGG")).toBeNull();
+    expect(normalizeHex("")).toBeNull();
+    expect(normalizeHex("#1234567")).toBeNull();
+  });
+});
+
+describe("themeToFile", () => {
+  it("emits the preset name when colors exactly match a preset", () => {
+    const f = themeToFile(PRESET_THEMES[3] as Theme); // Ocean
+    expect(f).toEqual({
+      version: 1,
+      preset: "Ocean",
+      custom: { accent: "#3B82F6", background: "#0E1118" },
+    });
+  });
+
+  it("is case-insensitive for preset matching", () => {
+    const f = themeToFile({
+      name: "Custom",
+      accent: "#3b82f6",
+      bgBase: "#0e1118",
+    });
+    expect(f.preset).toBe("Ocean");
+    expect(f.custom.accent).toBe("#3B82F6");
+  });
+
+  it("falls back to custom", () => {
+    const f = themeToFile(CUSTOM);
+    expect(f).toEqual({
+      version: 1,
+      preset: "custom",
+      custom: { accent: "#123456", background: "#654321" },
+    });
+  });
+
+  it("expands #RGB on write", () => {
+    const f = themeToFile({ name: "Custom", accent: "#fff", bgBase: "#abc" });
+    expect(f.custom).toEqual({ accent: "#FFFFFF", background: "#AABBCC" });
+  });
+});
+
+describe("resolveThemeFile", () => {
+  it("resolves a custom file to its colors", () => {
+    const t = resolveThemeFile({
+      preset: "custom",
+      custom: { accent: "#123456", background: "#654321" },
+    });
+    expect(t).toEqual({ name: "Custom", accent: "#123456", bgBase: "#654321" });
+  });
+
+  it("treats a missing version as 1", () => {
+    const t = resolveThemeFile({
+      preset: "custom",
+      custom: { accent: "#123456", background: "#654321" },
+    });
+    expect(t).not.toBeNull();
+  });
+
+  it("expands #RGB", () => {
+    const t = resolveThemeFile({
+      version: 1,
+      preset: "custom",
+      custom: { accent: "#fff", background: "#000" },
+    });
+    expect(t).toEqual({ name: "Custom", accent: "#FFFFFF", bgBase: "#000000" });
+  });
+
+  it("lets the named preset win over mismatched custom colors", () => {
+    const t = resolveThemeFile({
+      version: 1,
+      preset: "Ocean",
+      custom: { accent: "#111111", background: "#222222" },
+    });
+    expect(t).toEqual({ name: "Ocean", accent: "#3B82F6", bgBase: "#0E1118" });
+  });
+
+  it("round-trips every preset", () => {
+    for (const preset of PRESET_THEMES) {
+      const file = themeToFile(preset);
+      expect(file.preset).toBe(preset.name);
+      const resolved = resolveThemeFile(file);
+      expect(resolved).not.toBeNull();
+      expect(themesEqual(resolved!, preset)).toBe(true);
+    }
+  });
+
+  it("round-trips custom", () => {
+    const resolved = resolveThemeFile(themeToFile(CUSTOM));
+    expect(resolved).toEqual(CUSTOM);
+  });
+
+  it("rejects unknown versions", () => {
+    expect(
+      resolveThemeFile({
+        version: 2,
+        preset: "custom",
+        custom: { accent: "#123456", background: "#654321" },
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects unknown presets (case-sensitive)", () => {
+    const base: ThemeFile = {
+      preset: "ocean",
+      custom: { accent: "#3B82F6", background: "#0E1118" },
+    };
+    expect(resolveThemeFile(base)).toBeNull();
+    base.preset = "Solarized";
+    expect(resolveThemeFile(base)).toBeNull();
+  });
+
+  it("rejects malformed hex", () => {
+    expect(
+      resolveThemeFile({
+        preset: "custom",
+        custom: { accent: "#GGG", background: "#654321" },
+      }),
+    ).toBeNull();
+    expect(
+      resolveThemeFile({
+        preset: "custom",
+        custom: { accent: "#12345", background: "#654321" },
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects missing or malformed custom", () => {
+    expect(
+      resolveThemeFile({ preset: "custom" } as unknown as ThemeFile),
+    ).toBeNull();
+    expect(
+      resolveThemeFile({
+        preset: "custom",
+        custom: { accent: "#123456" },
+      } as unknown as ThemeFile),
+    ).toBeNull();
+    expect(resolveThemeFile(null)).toBeNull();
+    expect(resolveThemeFile("garbage" as unknown as ThemeFile)).toBeNull();
+  });
+});
+
+describe("themesEqual", () => {
+  it("ignores name and case", () => {
+    expect(
+      themesEqual(
+        { name: "Ocean", accent: "#3b82f6", bgBase: "#0e1118" },
+        { name: "Custom", accent: "#3B82F6", bgBase: "#0E1118" },
+      ),
+    ).toBe(true);
+  });
+
+  it("distinguishes different colors", () => {
+    expect(
+      themesEqual(
+        { name: "a", accent: "#111111", bgBase: "#000000" },
+        { name: "b", accent: "#111111", bgBase: "#000001" },
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -328,6 +328,10 @@ export interface ThemeFile {
 
 export const THEME_STORAGE_KEY = "sone.theme.v1";
 
+/** The `"preset"` meaning "use the `custom` colors". Mirrors `CUSTOM_PRESET`
+ *  in `src-tauri/src/theme_config.rs`. */
+export const CUSTOM_PRESET = "custom";
+
 const PRESET_NAMES = new Set(PRESET_THEMES.map((p) => p.name));
 
 /** Normalize a `#RGB`/`#RrGgBb` color to uppercase `#RRGGBB` */
@@ -365,7 +369,7 @@ export function resolveThemeFile(
   const bgBase = normalizeHex(String(custom.background));
   if (!accent || !bgBase) return null;
 
-  if (file.preset === "custom") {
+  if (file.preset === CUSTOM_PRESET) {
     return { name: "Custom", accent, bgBase };
   }
   if (!PRESET_NAMES.has(file.preset)) return null;
@@ -377,13 +381,18 @@ export function resolveThemeFile(
 export function themeToFile(theme: Theme): ThemeFile {
   const accent = normalizeHex(theme.accent) ?? theme.accent.toUpperCase();
   const bgBase = normalizeHex(theme.bgBase) ?? theme.bgBase.toUpperCase();
-  const preset = PRESET_THEMES.find(
+  // Trust the theme's own name rather than matching colors back to a preset --
+  // a custom theme that happens to land on a preset's colors is still custom.
+  // The colors are still checked so a stale name can't mislabel edited colors.
+  const isPreset = PRESET_THEMES.some(
     (p) =>
-      p.accent.toUpperCase() === accent && p.bgBase.toUpperCase() === bgBase,
+      p.name === theme.name &&
+      p.accent.toUpperCase() === accent &&
+      p.bgBase.toUpperCase() === bgBase,
   );
   return {
     version: 1,
-    preset: preset ? preset.name : "custom",
+    preset: isPreset ? theme.name : CUSTOM_PRESET,
     custom: { accent, background: bgBase },
   };
 }

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -314,3 +314,76 @@ export const PRESET_THEMES: Theme[] = [
   { name: "Meadow", accent: "#16A34A", bgBase: "#F2F6EE" },
   { name: "Blossom", accent: "#E11D48", bgBase: "#FEF3F2" },
 ];
+
+export interface ThemeCustom {
+  accent: string;
+  background: string;
+}
+
+export interface ThemeFile {
+  version?: number;
+  preset: string; // "custom" or an exact PRESET_THEMES name
+  custom: ThemeCustom;
+}
+
+export const THEME_STORAGE_KEY = "sone.theme.v1";
+
+const PRESET_NAMES = new Set(PRESET_THEMES.map((p) => p.name));
+
+/** Normalize a `#RGB`/`#RrGgBb` color to uppercase `#RRGGBB` */
+export function normalizeHex(input: string): string | null {
+  if (typeof input !== "string") return null;
+  const m = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.exec(input.trim());
+  if (!m) return null;
+  let h = m[1];
+  if (h.length === 3)
+    h = h
+      .split("")
+      .map((c) => c + c)
+      .join("");
+  return `#${h.toUpperCase()}`;
+}
+
+export function themesEqual(a: Theme, b: Theme): boolean {
+  return (
+    a.accent.toUpperCase() === b.accent.toUpperCase() &&
+    a.bgBase.toUpperCase() === b.bgBase.toUpperCase()
+  );
+}
+
+/** Validate a parsed theme file and resolve it to a Theme */
+export function resolveThemeFile(
+  file: ThemeFile | null | undefined,
+): Theme | null {
+  // Check version and parameters presence
+  if (!file || typeof file !== "object") return null;
+  if (file.version !== undefined && file.version !== 1) return null;
+  if (typeof file.preset !== "string") return null;
+  const custom = file.custom;
+  if (!custom || typeof custom !== "object") return null;
+  const accent = normalizeHex(String(custom.accent));
+  const bgBase = normalizeHex(String(custom.background));
+  if (!accent || !bgBase) return null;
+
+  if (file.preset === "custom") {
+    return { name: "Custom", accent, bgBase };
+  }
+  if (!PRESET_NAMES.has(file.preset)) return null;
+  const preset = PRESET_THEMES.find((p) => p.name === file.preset)!;
+  return { name: preset.name, accent: preset.accent, bgBase: preset.bgBase };
+}
+
+/** Serialize a live Theme to file shape */
+export function themeToFile(theme: Theme): ThemeFile {
+  const accent = normalizeHex(theme.accent) ?? theme.accent.toUpperCase();
+  const bgBase = normalizeHex(theme.bgBase) ?? theme.bgBase.toUpperCase();
+  const preset = PRESET_THEMES.find(
+    (p) =>
+      p.accent.toUpperCase() === accent && p.bgBase.toUpperCase() === bgBase,
+  );
+  return {
+    version: 1,
+    preset: preset ? preset.name : "custom",
+    custom: { accent, background: bgBase },
+  };
+}

--- a/src/lib/themeFile.test.ts
+++ b/src/lib/themeFile.test.ts
@@ -115,7 +115,7 @@ describe("syncThemeToFile (write-through, §5)", () => {
     invokeMock.mockResolvedValue(undefined);
     const { syncThemeToFile } = await freshThemeFile();
     await syncThemeToFile(OCEAN);
-    await syncThemeToFile({ ...OCEAN, name: "Renamed" }); // same colors
+    await syncThemeToFile({ ...OCEAN }); // same theme, fresh object
     const setCalls = invokeMock.mock.calls.filter(
       (c) => c[0] === "theme_file_set",
     );
@@ -208,5 +208,86 @@ describe("handleThemeFocusChange (window display, §6)", () => {
     );
     expect(invokeMock).toHaveBeenCalledTimes(1);
     expect(applied).toBeUndefined();
+  });
+});
+
+// The write-through subscription in AppInitializer fires once on mount, when
+// jotai's atomWithStorage hydrates themeAtom from localStorage. That echo must
+// never reach the file.
+async function simulateLaunchEcho(theme: typeof OCEAN) {
+  const { syncThemeToFile } = await import("./themeFile");
+  await syncThemeToFile(theme);
+}
+
+describe("startup echo must not touch theme.json", () => {
+  it("no write when the file already agrees with localStorage", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(OCEAN));
+    const mod = await freshThemeFile();
+    invokeMock.mockResolvedValue({
+      version: 1,
+      preset: "Ocean",
+      custom: { accent: "#3B82F6", background: "#0E1118" },
+    });
+    await mod.bootstrapThemeFile();
+    invokeMock.mockClear();
+
+    await simulateLaunchEcho(OCEAN);
+    expect(
+      invokeMock.mock.calls.filter((c) => c[0] === "theme_file_set"),
+    ).toHaveLength(0);
+  });
+
+  it("no write when the file names a preset but localStorage says Custom", async () => {
+    // Colors agree, so bootstrap's themesEqual check finds nothing to do --
+    // but the stored `name` still disagrees with the file's `preset`.
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ name: "Custom", accent: "#3B82F6", bgBase: "#0E1118" }),
+    );
+    const mod = await freshThemeFile();
+    invokeMock.mockResolvedValue({
+      version: 1,
+      preset: "Ocean",
+      custom: { accent: "#3B82F6", background: "#0E1118" },
+    });
+    await mod.bootstrapThemeFile();
+    invokeMock.mockClear();
+
+    await simulateLaunchEcho(OCEAN);
+    expect(
+      invokeMock.mock.calls.filter((c) => c[0] === "theme_file_set"),
+    ).toHaveLength(0);
+  });
+
+  it("never overwrites a file that failed to parse", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(CUSTOM));
+    const mod = await freshThemeFile();
+    invokeMock.mockImplementation((cmd: string) =>
+      cmd === "theme_file_get"
+        ? Promise.reject('invalid accent color "#ZZZ"')
+        : Promise.resolve(),
+    );
+    await mod.bootstrapThemeFile();
+    invokeMock.mockClear();
+
+    await simulateLaunchEcho(CUSTOM);
+    expect(
+      invokeMock.mock.calls.filter((c) => c[0] === "theme_file_set"),
+    ).toHaveLength(0);
+  });
+
+  it("a real theme change still repairs an unreadable file", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(CUSTOM));
+    const mod = await freshThemeFile();
+    invokeMock.mockImplementation((cmd: string) =>
+      cmd === "theme_file_get" ? Promise.reject("bad hex") : Promise.resolve(),
+    );
+    await mod.bootstrapThemeFile();
+    invokeMock.mockClear();
+
+    await mod.syncThemeToFile(OCEAN); // user picks a preset in Settings
+    const sets = invokeMock.mock.calls.filter((c) => c[0] === "theme_file_set");
+    expect(sets).toHaveLength(1);
+    expect(sets[0][1].file.preset).toBe("Ocean");
   });
 });

--- a/src/lib/themeFile.test.ts
+++ b/src/lib/themeFile.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const invokeMock = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+async function freshThemeFile() {
+  vi.resetModules();
+  return await import("./themeFile");
+}
+
+const STORAGE_KEY = "sone.theme.v1";
+const OCEAN = { name: "Ocean", accent: "#3B82F6", bgBase: "#0E1118" };
+const CUSTOM = { name: "Custom", accent: "#123456", bgBase: "#654321" };
+
+beforeEach(() => {
+  localStorage.clear();
+  invokeMock.mockReset();
+});
+
+describe("bootstrapThemeFile (pre-render, §4)", () => {
+  it("file wins: syncs the file's theme into localStorage", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(CUSTOM));
+    const { bootstrapThemeFile } = await freshThemeFile();
+    invokeMock
+      .mockResolvedValueOnce({
+        version: 1,
+        preset: "Ocean",
+        custom: { accent: "#3B82F6", background: "#0E1118" },
+      })
+      .mockResolvedValueOnce(undefined);
+    await bootstrapThemeFile();
+
+    expect(invokeMock).toHaveBeenCalledWith("theme_file_get");
+    expect(invokeMock).not.toHaveBeenCalledWith(
+      "theme_file_set",
+      expect.anything(),
+    );
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual(OCEAN);
+  });
+
+  it("absent file is created eagerly with the current theme", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(CUSTOM));
+    invokeMock
+      .mockResolvedValueOnce(null) // file absent
+      .mockResolvedValueOnce(undefined); // create
+
+    const { bootstrapThemeFile } = await freshThemeFile();
+    await bootstrapThemeFile();
+
+    const setCall = invokeMock.mock.calls.find(
+      (c) => c[0] === "theme_file_set",
+    );
+    expect(setCall).toBeDefined();
+    expect(setCall![1]).toEqual({
+      file: {
+        version: 1,
+        preset: "custom",
+        custom: { accent: "#123456", background: "#654321" },
+      },
+    });
+  });
+
+  it("invalid file is left untouched; localStorage keeps the app theme", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(CUSTOM));
+    invokeMock.mockRejectedValueOnce("unknown theme preset ...");
+
+    const { bootstrapThemeFile } = await freshThemeFile();
+    await bootstrapThemeFile();
+
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    expect(invokeMock).toHaveBeenCalledWith("theme_file_get");
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual(CUSTOM);
+  });
+
+  it("equal file: no localStorage write", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(OCEAN));
+    invokeMock.mockResolvedValueOnce({
+      version: 1,
+      preset: "Ocean",
+      custom: { accent: "#3B82F6", background: "#0E1118" },
+    });
+
+    const { bootstrapThemeFile } = await freshThemeFile();
+    await bootstrapThemeFile();
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual(OCEAN);
+  });
+
+  it("backend unavailable: degrades silently", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(OCEAN));
+    invokeMock.mockRejectedValueOnce("ipc closed");
+
+    const { bootstrapThemeFile } = await freshThemeFile();
+    await expect(bootstrapThemeFile()).resolves.toBeUndefined();
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual(OCEAN);
+  });
+});
+
+describe("syncThemeToFile (write-through, §5)", () => {
+  it("persists a theme change", async () => {
+    invokeMock.mockResolvedValueOnce(undefined);
+    const { syncThemeToFile } = await freshThemeFile();
+    await syncThemeToFile(CUSTOM);
+    expect(invokeMock).toHaveBeenCalledWith("theme_file_set", {
+      file: {
+        version: 1,
+        preset: "custom",
+        custom: { accent: "#123456", background: "#654321" },
+      },
+    });
+  });
+
+  it("skips no-op writes (echo of an already-persisted value)", async () => {
+    invokeMock.mockResolvedValue(undefined);
+    const { syncThemeToFile } = await freshThemeFile();
+    await syncThemeToFile(OCEAN);
+    await syncThemeToFile({ ...OCEAN, name: "Renamed" }); // same colors
+    const setCalls = invokeMock.mock.calls.filter(
+      (c) => c[0] === "theme_file_set",
+    );
+    expect(setCalls).toHaveLength(1);
+  });
+
+  it("swallows backend failures (localStorage-only mode)", async () => {
+    invokeMock.mockRejectedValue("read-only fs");
+    const { syncThemeToFile } = await freshThemeFile();
+    await expect(syncThemeToFile(OCEAN)).resolves.toBeUndefined();
+  });
+});
+
+describe("handleThemeFocusChange (window display, §6)", () => {
+  it("does nothing when focused is false", async () => {
+    invokeMock.mockResolvedValue(null);
+    const { handleThemeFocusChange } = await freshThemeFile();
+    let applied: unknown = undefined;
+    await handleThemeFocusChange(
+      false,
+      () => CUSTOM,
+      (t) => (applied = t),
+    );
+    expect(invokeMock).not.toHaveBeenCalled();
+    expect(applied).toBeUndefined();
+  });
+
+  it("applies an external change on focused:true", async () => {
+    invokeMock.mockResolvedValueOnce({
+      version: 1,
+      preset: "Forest",
+      custom: { accent: "#22C55E", background: "#0E1410" },
+    });
+    const { handleThemeFocusChange } = await freshThemeFile();
+    let applied: unknown = undefined;
+    await handleThemeFocusChange(
+      true,
+      () => CUSTOM,
+      (t) => (applied = t),
+    );
+    expect(applied).toEqual({
+      name: "Forest",
+      accent: "#22C55E",
+      bgBase: "#0E1410",
+    });
+  });
+
+  it("is a no-op when the file matches the current theme", async () => {
+    invokeMock.mockResolvedValue({
+      version: 1,
+      preset: "custom",
+      custom: { accent: "#123456", background: "#654321" },
+    });
+    const { handleThemeFocusChange } = await freshThemeFile();
+    let applied: unknown = undefined;
+    await handleThemeFocusChange(
+      true,
+      () => CUSTOM,
+      (t) => (applied = t),
+    );
+    expect(applied).toBeUndefined();
+    expect(invokeMock).toHaveBeenCalledTimes(1); // read only, no write
+  });
+
+  it("recreates a deleted file from the live theme", async () => {
+    invokeMock
+      .mockResolvedValueOnce(null) // deleted externally
+      .mockResolvedValueOnce(undefined); // recreate
+    const { handleThemeFocusChange } = await freshThemeFile();
+    await handleThemeFocusChange(
+      true,
+      () => CUSTOM,
+      () => {},
+    );
+    const setCall = invokeMock.mock.calls.find(
+      (c) => c[0] === "theme_file_set",
+    );
+    expect(setCall).toBeDefined();
+    expect(setCall![1].file.preset).toBe("custom");
+  });
+
+  it("ignores an invalid file (never clobbers)", async () => {
+    invokeMock.mockRejectedValueOnce("bad hex");
+    const { handleThemeFocusChange } = await freshThemeFile();
+    let applied: unknown = undefined;
+    await handleThemeFocusChange(
+      true,
+      () => CUSTOM,
+      (t) => (applied = t),
+    );
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    expect(applied).toBeUndefined();
+  });
+});

--- a/src/lib/themeFile.ts
+++ b/src/lib/themeFile.ts
@@ -20,8 +20,21 @@ function warnWrite(err: unknown) {
   }
 }
 
-/** Last successfully persisted serialized file (no-op write guard) */
+/**
+ * Serialized form of the file we last wrote, or last agreed with on disk.
+ *
+ * This guards against the echo that arrives at startup: jotai's
+ * `atomWithStorage` hydrates `themeAtom` inside `onMount`, so the
+ * write-through subscription in `AppInitializer` fires once on mount even
+ * when nothing changed. Guarding on what we *would write* (rather than on the
+ * bytes on disk) means a hand-written file is left alone until the theme
+ * genuinely changes.
+ */
 let lastPersisted = "";
+
+function markPersisted(theme: Theme) {
+  lastPersisted = JSON.stringify(themeToFile(theme));
+}
 
 function readStoredTheme(): Theme {
   try {
@@ -51,7 +64,12 @@ export async function bootstrapThemeFile(): Promise<void> {
   try {
     file = await invoke<ThemeFile | null>("theme_file_get");
   } catch {
-    return; // Invalid file or backend unavailable
+    // Invalid file or backend unavailable. Seed the guard from the theme we
+    // are about to render so the mount-time echo (below) cannot overwrite a
+    // file the user may be part-way through editing. A deliberate theme
+    // change still writes, repairing the file.
+    markPersisted(current);
+    return;
   }
   if (file === null) {
     // Create if not exists
@@ -65,10 +83,16 @@ export async function bootstrapThemeFile(): Promise<void> {
     return;
   }
   const resolved = resolveThemeFile(file);
-  if (resolved && !themesEqual(resolved, current)) {
-    // If theme in file != from localStorage, update
-    writeStoredTheme(resolved);
+  if (!resolved) {
+    markPersisted(current);
+    return;
   }
+  // Mirror the file into localStorage unconditionally, not just when the
+  // colors differ: a stored `name` of "Custom" against a file preset of
+  // "Ocean" describes the same colors but serializes differently, and the
+  // disagreement would surface as a spurious write on the next launch.
+  writeStoredTheme(resolved);
+  markPersisted(resolved);
 }
 
 export async function syncThemeToFile(theme: Theme): Promise<void> {
@@ -100,14 +124,18 @@ export async function handleThemeFocusChange(
     const current = getCurrent();
     try {
       await invoke("theme_file_set", { file: themeToFile(current) });
-      lastPersisted = JSON.stringify(themeToFile(current));
+      markPersisted(current);
     } catch (err) {
       warnWrite(err);
     }
     return;
   }
   const resolved = resolveThemeFile(file);
-  if (resolved && !themesEqual(resolved, getCurrent())) {
+  if (!resolved) return;
+  if (!themesEqual(resolved, getCurrent())) {
     setCurrent(resolved);
   }
+  // Either way the file and the live theme now agree -- record that, so the
+  // write-through this may have just triggered does not echo back to disk.
+  markPersisted(resolved);
 }

--- a/src/lib/themeFile.ts
+++ b/src/lib/themeFile.ts
@@ -1,0 +1,113 @@
+import { invoke } from "@tauri-apps/api/core";
+import {
+  PRESET_THEMES,
+  THEME_STORAGE_KEY,
+  resolveThemeFile,
+  themeToFile,
+  themesEqual,
+  type Theme,
+  type ThemeFile,
+} from "./theme";
+
+let writeWarned = false;
+function warnWrite(err: unknown) {
+  if (!writeWarned) {
+    writeWarned = true;
+    console.warn(
+      "[theme] theme.json unavailable — continuing in localStorage-only mode:",
+      err,
+    );
+  }
+}
+
+/** Last successfully persisted serialized file (no-op write guard) */
+let lastPersisted = "";
+
+function readStoredTheme(): Theme {
+  try {
+    const raw = localStorage.getItem(THEME_STORAGE_KEY);
+    if (raw) {
+      const t = JSON.parse(raw) as Theme | null;
+      if (t && typeof t.accent === "string" && typeof t.bgBase === "string") {
+        return t;
+      }
+    }
+  } catch {
+    // fall through to default
+  }
+  return PRESET_THEMES[0];
+}
+
+function writeStoredTheme(theme: Theme) {
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, JSON.stringify(theme));
+  } catch {}
+}
+
+/** Pre-render bootstrap */
+export async function bootstrapThemeFile(): Promise<void> {
+  const current = readStoredTheme();
+  let file: ThemeFile | null;
+  try {
+    file = await invoke<ThemeFile | null>("theme_file_get");
+  } catch {
+    return; // Invalid file or backend unavailable
+  }
+  if (file === null) {
+    // Create if not exists
+    const newFile = themeToFile(current);
+    try {
+      await invoke("theme_file_set", { file: newFile });
+      lastPersisted = JSON.stringify(newFile);
+    } catch (err) {
+      warnWrite(err);
+    }
+    return;
+  }
+  const resolved = resolveThemeFile(file);
+  if (resolved && !themesEqual(resolved, current)) {
+    // If theme in file != from localStorage, update
+    writeStoredTheme(resolved);
+  }
+}
+
+export async function syncThemeToFile(theme: Theme): Promise<void> {
+  const file = themeToFile(theme);
+  const json = JSON.stringify(file);
+  if (json === lastPersisted) return;
+  try {
+    await invoke("theme_file_set", { file });
+    lastPersisted = json;
+  } catch (err) {
+    warnWrite(err);
+  }
+}
+
+export async function handleThemeFocusChange(
+  focused: boolean,
+  getCurrent: () => Theme,
+  setCurrent: (theme: Theme) => void,
+): Promise<void> {
+  if (!focused) return;
+
+  let file: ThemeFile | null;
+  try {
+    file = await invoke<ThemeFile | null>("theme_file_get");
+  } catch {
+    return; // invalid file, keep in-app theme
+  }
+  if (file === null) {
+    const current = getCurrent();
+    try {
+      await invoke("theme_file_set", { file: themeToFile(current) });
+      lastPersisted = JSON.stringify(themeToFile(current));
+    } catch (err) {
+      warnWrite(err);
+    }
+    return;
+  }
+  const resolved = resolveThemeFile(file);
+  if (resolved && !themesEqual(resolved, getCurrent())) {
+    setCurrent(resolved);
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,22 @@
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import { bootstrapThemeFile } from "./lib/themeFile";
 
-ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  <App />,
-);
+/**
+ * Resolve the external theme file (~/.config/sone/theme.json) BEFORE the
+ * first render so themeAtom's synchronous localStorage hydration already
+ * reflects the file's theme.
+ *
+ * Also in promise so a stuck IPC cannot block startup.
+ */
+async function main() {
+  await Promise.race([
+    bootstrapThemeFile(),
+    new Promise<void>((resolve) => setTimeout(resolve, 2000)),
+  ]);
+  ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+    <App />,
+  );
+}
+
+void main();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,5 +8,6 @@ export default defineConfig({
   plugins: [react()],
   test: {
     environment: "jsdom",
+    setupFiles: ["./vitest.setup.ts"],
   },
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,35 @@
+/**
+ * Vitest global setup.
+ *
+ * jsdom build does not expose `localStorage` on the global object,
+ * provide an in-memory shim so themeFile tests can rely on it.
+ */
+
+function makeMemoryStorage(): Storage {
+  const m = new Map<string, string>();
+  return {
+    getItem: (k: string) => (m.has(k) ? m.get(k)! : null),
+    setItem: (k: string, v: string) => {
+      m.set(k, String(v));
+    },
+    removeItem: (k: string) => {
+      m.delete(k);
+    },
+    clear: () => m.clear(),
+    key: (i: number) => Array.from(m.keys())[i] ?? null,
+    get length() {
+      return m.size;
+    },
+  };
+}
+
+if (
+  typeof globalThis.localStorage === "undefined" ||
+  globalThis.localStorage === null
+) {
+  Object.defineProperty(globalThis, "localStorage", {
+    value: makeMemoryStorage(),
+    configurable: true,
+    writable: true,
+  });
+}


### PR DESCRIPTION
References issue #206.

Screenshot:
<img width="2562" height="1441" alt="image" src="https://github.com/user-attachments/assets/0e4918ba-bf35-4c1a-9ad0-71e35acf4a2f" />


All new tests passed and I user tested it.

For user testing what I did was:
1.  launching the app with theme.json not created (defaults to the default preset).
2. reopening the UI with no change.
3. closing the UI, changing the theme file and then open the UI again.
4. changing the theme file while UI is still open.
5. deleting theme.json while the app is running (creates it back with actual config on focus).

Possible unwanted behaviour: If in a previous version of the app you did set up your colors or preset, during the bootstrap check for creating theme.json the code doesn't have the context of localStorage yet. So it resets your theme once. I don't know how to work around this.
