### PR TITLE
Add activity feed page

### DIFF
--- a/src-tauri/src/commands/feed.rs
+++ b/src-tauri/src/commands/feed.rs
@@ -7,9 +7,16 @@ use crate::AppState;
 
 /// Invalidation tag for every cached feed entry. Intentionally undiscriminated —
 /// `mark_feed_seen` drops the whole tag, so it must cover all users' entries.
+///
+/// Ordering assumption: on page open, `get_feed`'s `put` and `mark_feed_seen`'s
+/// `invalidate_tag` are unordered, and a `put` landing second would re-tag a body
+/// with the stale nonzero `unseenCount` for a full TTL. Safe today only because
+/// `mark_feed_seen` waits on the `tidal_client` mutex `get_feed` holds across its
+/// fetch and then makes its own network round-trip, while the `put` is a local
+/// disk write. Reintroducing SWR to `get_feed` makes that race live.
 const FEED_CACHE_TAG: &str = "feed";
 
-/// Cache key prefix for the activity feed. Scoped per user, matching the
+/// Cache key for the activity feed. Scoped per user, matching the
 /// convention of every other user-scoped cache in this codebase
 /// (`user-playlists:{id}`, `fav-albums:{id}`, …) — logging out does not purge
 /// the disk cache, so an undiscriminated key would serve the previous

--- a/src-tauri/src/commands/feed.rs
+++ b/src-tauri/src/commands/feed.rs
@@ -5,13 +5,15 @@ use crate::error::SoneError;
 use crate::tidal_api::FeedResponse;
 use crate::AppState;
 
+/// Invalidation tag for every cached feed entry. Intentionally undiscriminated —
+/// `mark_feed_seen` drops the whole tag, so it must cover all users' entries.
+const FEED_CACHE_TAG: &str = "feed";
+
 /// Cache key prefix for the activity feed. Scoped per user, matching the
 /// convention of every other user-scoped cache in this codebase
 /// (`user-playlists:{id}`, `fav-albums:{id}`, …) — logging out does not purge
 /// the disk cache, so an undiscriminated key would serve the previous
 /// account's feed and unread count after an account switch.
-const FEED_CACHE_TAG: &str = "feed";
-
 fn feed_cache_key(user_id: u64) -> String {
     format!("feed:activities:{}", user_id)
 }
@@ -50,4 +52,17 @@ pub async fn get_feed(state: State<'_, AppState>, user_id: u64) -> Result<FeedRe
     }
 
     Ok(feed)
+}
+
+/// Mark all feed activities seen, then drop the cached feed so the next
+/// `get_feed` refetches instead of replaying a body with a nonzero count.
+#[tauri::command(rename_all = "camelCase")]
+pub async fn mark_feed_seen(state: State<'_, AppState>, user_id: u64) -> Result<(), SoneError> {
+    let client = state.tidal_client.lock().await;
+    let result = client.mark_feed_seen(user_id).await;
+    drop(client);
+
+    state.disk_cache.invalidate_tag(FEED_CACHE_TAG).await;
+
+    result
 }

--- a/src-tauri/src/commands/feed.rs
+++ b/src-tauri/src/commands/feed.rs
@@ -1,0 +1,53 @@
+use tauri::State;
+
+use crate::cache::{CacheResult, CacheTier};
+use crate::error::SoneError;
+use crate::tidal_api::FeedResponse;
+use crate::AppState;
+
+/// Cache key prefix for the activity feed. Scoped per user, matching the
+/// convention of every other user-scoped cache in this codebase
+/// (`user-playlists:{id}`, `fav-albums:{id}`, …) — logging out does not purge
+/// the disk cache, so an undiscriminated key would serve the previous
+/// account's feed and unread count after an account switch.
+const FEED_CACHE_TAG: &str = "feed";
+
+fn feed_cache_key(user_id: u64) -> String {
+    format!("feed:activities:{}", user_id)
+}
+
+/// Fetch the activity feed.
+///
+/// Uses a plain TTL cache rather than the stale-while-revalidate pattern in
+/// `get_page_section`: a background refresh would race the optimistic badge
+/// zeroing in `mark_feed_seen` and resurrect the unread dot. At a 15-minute
+/// `UserContent` TTL on a handful of rows, SWR buys nothing.
+#[tauri::command(rename_all = "camelCase")]
+pub async fn get_feed(state: State<'_, AppState>, user_id: u64) -> Result<FeedResponse, SoneError> {
+    log::debug!("[get_feed] user_id={}", user_id);
+
+    let cache_key = feed_cache_key(user_id);
+    if let CacheResult::Fresh(bytes) = state
+        .disk_cache
+        .get(&cache_key, CacheTier::UserContent)
+        .await
+    {
+        if let Ok(feed) = serde_json::from_slice::<FeedResponse>(&bytes) {
+            return Ok(feed);
+        }
+    }
+
+    let mut client = state.tidal_client.lock().await;
+    let feed = client.fetch_feed(user_id).await?;
+    drop(client);
+
+    if let Ok(json) = serde_json::to_vec(&feed) {
+        state
+            .disk_cache
+            .put(&cache_key, &json, CacheTier::UserContent, &[FEED_CACHE_TAG])
+            .await
+            .ok();
+    }
+
+    Ok(feed)
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod feed;
 pub mod library;
 pub mod mcp;
 pub mod metadata;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -954,6 +954,7 @@ pub fn run() {
             commands::pages::debug_home_page_raw,
             // feed
             commands::feed::get_feed,
+            commands::feed::mark_feed_seen,
             // search
             commands::search::search_tidal,
             commands::search::get_suggestions,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -952,6 +952,8 @@ pub fn run() {
             commands::pages::get_artist_top_tracks_all,
             commands::pages::get_artist_view_all,
             commands::pages::debug_home_page_raw,
+            // feed
+            commands::feed::get_feed,
             // search
             commands::search::search_tidal,
             commands::search::get_suggestions,

--- a/src-tauri/src/tidal_api.rs
+++ b/src-tauri/src/tidal_api.rs
@@ -5875,6 +5875,49 @@ impl TidalClient {
 
         Ok(feed)
     }
+
+    /// Mark every feed activity as seen.
+    ///
+    /// Hand-rolled because no authenticated PUT helper exists. Two things the GET
+    /// path gives for free must be done manually: the v2 client-version header
+    /// (v2 returns 400/404 without it), and routing through `self.send` so the
+    /// rate gate still applies. An expired token hard-401s with no refresh retry —
+    /// callers treat failure as non-fatal.
+    pub async fn mark_feed_seen(&self, user_id: u64) -> Result<(), SoneError> {
+        let tokens = self.tokens.as_ref().ok_or(SoneError::NotAuthenticated)?;
+
+        log::debug!("[mark_feed_seen] user_id={}", user_id);
+
+        let user_id_str = user_id.to_string();
+        let req = self
+            .client
+            .put(format!("{}/feed/activities/seen", TIDAL_API_V2_URL))
+            .header("Authorization", format!("Bearer {}", tokens.access_token))
+            .header("x-tidal-client-version", TIDAL_CLIENT_VERSION)
+            .query(&[
+                ("userId", user_id_str.as_str()),
+                ("countryCode", self.country_code.as_str()),
+            ]);
+        let response = self.send(req).await?;
+
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+
+        log::debug!(
+            "[mark_feed_seen] status={}, body={}",
+            status,
+            &body[..body.len().min(500)]
+        );
+
+        if !status.is_success() {
+            return Err(SoneError::Api {
+                status: status.as_u16(),
+                body,
+            });
+        }
+
+        Ok(())
+    }
 }
 
 // ==================== Profile ====================

--- a/src-tauri/src/tidal_api.rs
+++ b/src-tauri/src/tidal_api.rs
@@ -640,6 +640,139 @@ pub struct TidalVideo {
     pub artists: Option<Vec<TidalArtist>>,
 }
 
+// ==================== Feed (activity notifications) ====================
+
+/// Which entity a feed activity carries. The payload key in
+/// `followableActivity` is the real discriminant; this is its typed form.
+///
+/// `rename_all` must live on the enum — a struct-level `rename_all` does not
+/// rename enum variants, and the wire contract is lowercase.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FeedItemKind {
+    Mix,
+    Album,
+    Unknown,
+}
+
+/// One flattened feed row. `item` is the raw payload, passed through untouched
+/// so the frontend's existing item helpers can render and play it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FeedItem {
+    pub kind: FeedItemKind,
+    pub activity_type: String,
+    pub occurred_at: String,
+    pub seen: bool,
+    pub item: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FeedResponse {
+    pub items: Vec<FeedItem>,
+    pub unseen_count: u32,
+}
+
+#[derive(Debug, Deserialize)]
+struct FeedActivitiesEnvelope {
+    #[serde(default)]
+    activities: Vec<FeedActivityEntry>,
+    #[serde(default)]
+    stats: Option<FeedStats>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FeedStats {
+    #[serde(default)]
+    total_not_seen_activities: u32,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FeedActivityEntry {
+    #[serde(default)]
+    followable_activity: Option<serde_json::Value>,
+    #[serde(default)]
+    seen: bool,
+}
+
+/// Keys inside `followableActivity` that are metadata, not the payload.
+const FEED_META_KEYS: [&str; 2] = ["activityType", "occurredAt"];
+
+/// Flatten one `followableActivity` object into a `FeedItem`.
+///
+/// The object holds exactly one payload, keyed by content type
+/// (`historyMix`, `album`, …). Returns `None` when no payload object is
+/// present at all — such an entry has nothing to render.
+pub fn flatten_feed_activity(seen: bool, activity: &serde_json::Value) -> Option<FeedItem> {
+    let obj = activity.as_object()?;
+
+    let activity_type = obj
+        .get("activityType")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let occurred_at = obj
+        .get("occurredAt")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+
+    let (key, payload) = obj
+        .iter()
+        .find(|(k, v)| !FEED_META_KEYS.contains(&k.as_str()) && v.is_object())?;
+
+    let kind = match key.as_str() {
+        "historyMix" => FeedItemKind::Mix,
+        "album" => FeedItemKind::Album,
+        other => {
+            log::warn!(
+                "[feed] unrecognized payload key '{}' (activityType={})",
+                other,
+                activity_type
+            );
+            FeedItemKind::Unknown
+        }
+    };
+
+    Some(FeedItem {
+        kind,
+        activity_type,
+        occurred_at,
+        seen,
+        item: payload.clone(),
+    })
+}
+
+/// Parse a feed response body into flattened rows.
+pub fn parse_feed_body(body: &str) -> Result<FeedResponse, serde_json::Error> {
+    let envelope: FeedActivitiesEnvelope = serde_json::from_str(body)?;
+
+    let items: Vec<FeedItem> = envelope
+        .activities
+        .iter()
+        .filter_map(|entry| {
+            entry
+                .followable_activity
+                .as_ref()
+                .and_then(|a| flatten_feed_activity(entry.seen, a))
+        })
+        .collect();
+
+    let unseen_count = envelope
+        .stats
+        .as_ref()
+        .map(|s| s.total_not_seen_activities)
+        .unwrap_or(0);
+
+    Ok(FeedResponse {
+        items,
+        unseen_count,
+    })
+}
+
 // ==================== v2 Home Feed MIX types ====================
 // These structs document the v2 MIX shape. Not yet consumed by backend code
 // (home feed items pass through as raw Value), but available for future typed parsing.
@@ -5708,6 +5841,40 @@ impl TidalClient {
         }
         Ok(())
     }
+
+    /// Fetch the activity feed. `user_id` comes from the caller — `self.tokens`
+    /// may carry `None` on the token-import path.
+    pub async fn fetch_feed(&mut self, user_id: u64) -> Result<FeedResponse, SoneError> {
+        let url = format!("{}/feed/activities", TIDAL_API_V2_URL);
+        let country_code = self.country_code.clone();
+        let user_id_str = user_id.to_string();
+
+        let body = self
+            .api_get_body(
+                &url,
+                &[
+                    ("userId", user_id_str.as_str()),
+                    ("countryCode", country_code.as_str()),
+                    ("locale", "en_US"),
+                    ("deviceType", "BROWSER"),
+                    ("platform", "WEB"),
+                ],
+            )
+            .await?;
+
+        let feed = parse_feed_body(&body).map_err(|e| {
+            log::error!("[fetch_feed] parse error: {}", e);
+            SoneError::Parse(format!("feed parse error: {}", e))
+        })?;
+
+        log::debug!(
+            "[fetch_feed] items={} unseen={}",
+            feed.items.len(),
+            feed.unseen_count
+        );
+
+        Ok(feed)
+    }
 }
 
 // ==================== Profile ====================
@@ -6827,5 +6994,164 @@ mod direct_hit_tests {
         });
         let hit = DirectHitItem::from_typed_value(&album).expect("ALBUMS hit must parse");
         assert!(hit.track.is_none());
+    }
+}
+
+#[cfg(test)]
+mod feed_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn feed_item_kind_serializes_lowercase() {
+        assert_eq!(
+            serde_json::to_string(&FeedItemKind::Mix).unwrap(),
+            "\"mix\""
+        );
+        assert_eq!(
+            serde_json::to_string(&FeedItemKind::Album).unwrap(),
+            "\"album\""
+        );
+        assert_eq!(
+            serde_json::to_string(&FeedItemKind::Unknown).unwrap(),
+            "\"unknown\""
+        );
+    }
+
+    #[test]
+    fn flattens_history_mix_activity() {
+        let activity = json!({
+            "historyMix": {
+                "id": "0011112222333344445555666677",
+                "mixType": "HISTORY_MONTHLY_MIX",
+                "title": "July 2026",
+                "subTitle": "Some Artist and more",
+                "images": {
+                    "MEDIUM": { "width": 533, "height": 533, "url": "https://example.invalid/a.jpg" }
+                }
+            },
+            "activityType": "NEW_HISTORY_MIX",
+            "occurredAt": "2026-08-01T00:00:00.000Z"
+        });
+
+        let item = flatten_feed_activity(true, &activity).expect("should flatten");
+
+        assert!(matches!(item.kind, FeedItemKind::Mix));
+        assert_eq!(item.activity_type, "NEW_HISTORY_MIX");
+        assert_eq!(item.occurred_at, "2026-08-01T00:00:00.000Z");
+        assert!(item.seen);
+        assert_eq!(item.item["mixType"], "HISTORY_MONTHLY_MIX");
+        assert_eq!(
+            item.item["images"]["MEDIUM"]["url"],
+            "https://example.invalid/a.jpg"
+        );
+    }
+
+    #[test]
+    fn flattens_album_activity() {
+        let activity = json!({
+            "album": {
+                "id": 1234,
+                "title": "Some Single",
+                "type": "SINGLE",
+                "cover": "00000000-1111-2222-3333-444444444444",
+                "artists": [ { "id": 9, "name": "Some Artist" } ]
+            },
+            "activityType": "NEW_ALBUM_RELEASE",
+            "occurredAt": "2026-06-05T00:00:00.000Z"
+        });
+
+        let item = flatten_feed_activity(false, &activity).expect("should flatten");
+
+        assert!(matches!(item.kind, FeedItemKind::Album));
+        assert!(!item.seen);
+        assert_eq!(item.item["id"], 1234);
+        assert_eq!(item.item["artists"][0]["name"], "Some Artist");
+    }
+
+    #[test]
+    fn unrecognized_payload_key_becomes_unknown() {
+        let activity = json!({
+            "somethingNew": { "id": 7, "title": "Mystery" },
+            "activityType": "NEW_MYSTERY_THING",
+            "occurredAt": "2026-01-01T00:00:00.000Z"
+        });
+
+        let item = flatten_feed_activity(true, &activity).expect("should still flatten");
+
+        assert!(matches!(item.kind, FeedItemKind::Unknown));
+        assert_eq!(item.item["title"], "Mystery");
+    }
+
+    #[test]
+    fn activity_without_payload_object_is_dropped() {
+        let activity = json!({
+            "activityType": "NEW_NOTHING",
+            "occurredAt": "2026-01-01T00:00:00.000Z"
+        });
+
+        assert!(flatten_feed_activity(true, &activity).is_none());
+    }
+
+    #[test]
+    fn parses_envelope_with_both_kinds_and_unseen_count() {
+        let body = json!({
+            "activities": [
+                {
+                    "followableActivity": {
+                        "historyMix": { "id": "abc", "mixType": "HISTORY_MONTHLY_MIX" },
+                        "activityType": "NEW_HISTORY_MIX",
+                        "occurredAt": "2026-08-01T00:00:00.000Z"
+                    },
+                    "seen": false
+                },
+                {
+                    "followableActivity": {
+                        "album": { "id": 1, "title": "T" },
+                        "activityType": "NEW_ALBUM_RELEASE",
+                        "occurredAt": "2026-06-05T00:00:00.000Z"
+                    },
+                    "seen": true
+                }
+            ],
+            "stats": { "totalNotSeenActivities": 3 }
+        })
+        .to_string();
+
+        let feed = parse_feed_body(&body).expect("should parse");
+
+        assert_eq!(feed.items.len(), 2);
+        assert_eq!(feed.unseen_count, 3);
+        assert!(matches!(feed.items[0].kind, FeedItemKind::Mix));
+        assert!(!feed.items[0].seen);
+        assert!(matches!(feed.items[1].kind, FeedItemKind::Album));
+    }
+
+    #[test]
+    fn missing_stats_yields_zero_unseen() {
+        let body = json!({ "activities": [] }).to_string();
+        let feed = parse_feed_body(&body).expect("should parse");
+        assert_eq!(feed.unseen_count, 0);
+        assert!(feed.items.is_empty());
+    }
+
+    /// A feed parse failure must surface as `SoneError::Parse`, whose wire
+    /// `message` is a plain string. `SoneError::Api` serializes `message` as a
+    /// `{status, body}` object, which the frontend cannot render as text.
+    #[test]
+    fn parse_failure_serializes_message_as_a_string() {
+        let err = parse_feed_body("not json").expect_err("should fail to parse");
+        let parse_err = SoneError::Parse(format!("feed parse error: {}", err));
+
+        let wire = serde_json::to_value(&parse_err).unwrap();
+        assert_eq!(wire["kind"], "Parse");
+        assert!(wire["message"].is_string());
+
+        let api_wire = serde_json::to_value(SoneError::Api {
+            status: 200,
+            body: "x".to_string(),
+        })
+        .unwrap();
+        assert!(api_wire["message"].is_object());
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import ProfilePlaylistsPage from "./components/ProfilePlaylistsPage";
 import MixPage from "./components/MixPage";
 import ExplorePage from "./components/ExplorePage";
 import ExploreSubPage from "./components/ExploreSubPage";
+import FeedPage from "./components/FeedPage";
 import LibraryViewAll from "./components/LibraryViewAll";
 import Login from "./components/Login";
 import { AppInitializer } from "./components/AppInitializer";
@@ -187,6 +188,8 @@ function AppContent() {
         );
       case "explore":
         return <ExplorePage />;
+      case "feed":
+        return <FeedPage />;
       case "explorePage":
         return (
           <ExploreSubPage

--- a/src/api/tidal.ts
+++ b/src/api/tidal.ts
@@ -8,6 +8,7 @@ import type {
   ArtistPageData,
   Credit,
   FavoriteMix,
+  FeedResponse,
   HomePageCached,
   HomePageResponse,
   Lyrics,
@@ -1117,6 +1118,16 @@ export async function getAllFavoriteIds(
   userId: number,
 ): Promise<AllFavoriteIds> {
   return invoke<AllFavoriteIds>("get_all_favorite_ids", { userId });
+}
+
+// ==================== Feed ====================
+
+/**
+ * Activity feed. Deliberately uncached on this side — `get_feed` owns the
+ * cache, and a second TTL layer here would mask backend invalidation.
+ */
+export async function getFeed(userId: number): Promise<FeedResponse> {
+  return invoke<FeedResponse>("get_feed", { userId });
 }
 
 // ==================== Profile ====================

--- a/src/api/tidal.ts
+++ b/src/api/tidal.ts
@@ -1130,6 +1130,12 @@ export async function getFeed(userId: number): Promise<FeedResponse> {
   return invoke<FeedResponse>("get_feed", { userId });
 }
 
+/** Mark all feed activities seen. Failure is non-fatal — the caller clears the
+ *  badge locally regardless, and the next startup fetch reports the truth. */
+export async function markFeedSeen(userId: number): Promise<void> {
+  return invoke<void>("mark_feed_seen", { userId });
+}
+
 // ==================== Profile ====================
 
 export async function getProfile(userId: number): Promise<Profile> {

--- a/src/atoms/ui.ts
+++ b/src/atoms/ui.ts
@@ -8,6 +8,10 @@ export const maximizedLyricsAtom = atom(false);
 export const sidebarCollapsedAtom = atom(false);
 export const miniplayerOpenAtom = atom(false);
 
+/** Unread activity-feed count, from `stats.totalNotSeenActivities`. Drives the
+ *  sidebar Feed dot. Zeroed optimistically when the Feed page is opened. */
+export const feedUnseenCountAtom = atom(0);
+
 // `true` = native OS chrome (escape hatch), `false` = custom React titlebar
 // (default after migration). Hydrated from Rust `get_decorations` on app boot.
 export const decorationsAtom = atom<boolean>(false);

--- a/src/components/AppInitializer.tsx
+++ b/src/components/AppInitializer.tsx
@@ -65,6 +65,7 @@ import {
 import {
   decorationsAtom,
   drawerOpenAtom,
+  feedUnseenCountAtom,
   maximizedPlayerAtom,
 } from "../atoms/ui";
 import { proxySettingsAtom, type ProxySettings } from "../atoms/proxy";
@@ -93,6 +94,7 @@ import {
   normalizePlaylistFolders,
   getTrack,
   getProfile,
+  getFeed,
 } from "../api/tidal";
 import { pickProfileAvatarHref } from "./ProfilePage";
 
@@ -209,6 +211,7 @@ export function AppInitializer() {
   const setDrawerOpen = useSetAtom(drawerOpenAtom);
   const setMaximized = useSetAtom(maximizedPlayerAtom);
   const setDecorations = useSetAtom(decorationsAtom);
+  const setFeedUnseenCount = useSetAtom(feedUnseenCountAtom);
   const { showToast } = useToast();
 
   // ---- Store for one-time reads (volume, queue, history, etc.) — no subscription ----
@@ -455,6 +458,12 @@ export function AppInitializer() {
       .catch((error) =>
         console.error("Failed to load favorite video IDs:", error),
       );
+
+    // Activity feed — fetched at startup so the sidebar unread dot is correct
+    // before the user ever opens the page. Also warms the backend feed cache.
+    getFeed(userId)
+      .then((feed) => setFeedUnseenCount(feed.unseenCount))
+      .catch((error) => console.error("Failed to load feed:", error));
 
     // Non-blocking background preload (2s delay to avoid startup congestion)
     const timer = setTimeout(() => {

--- a/src/components/FeedPage.test.tsx
+++ b/src/components/FeedPage.test.tsx
@@ -9,6 +9,7 @@ import {
 } from "@testing-library/react";
 import { Provider, createStore } from "jotai";
 import { authTokensAtom } from "../atoms/auth";
+import { feedUnseenCountAtom } from "../atoms/ui";
 import type { FeedResponse } from "../types";
 
 const getFeed = vi.fn();
@@ -34,14 +35,20 @@ vi.mock("../hooks/useMediaPlay", () => ({
 import FeedPage from "./FeedPage";
 
 /** FeedPage reads the user id from `authTokensAtom` and bails when it is absent,
- *  so every render needs a store with one set — the default atom value is null. */
+ *  so every render needs a store with one set — the default atom value is null.
+ *
+ *  The unseen count is seeded nonzero and the store is returned so callers can
+ *  assert the badge was actually cleared: `feedUnseenCountAtom` defaults to 0,
+ *  so asserting against a fresh store would pass even with the clearing line
+ *  deleted. */
 function renderFeed() {
   const store = createStore();
   store.set(authTokensAtom, { user_id: 1 } as never);
+  store.set(feedUnseenCountAtom, 3);
   const wrapper = ({ children }: PropsWithChildren) => (
     <Provider store={store}>{children}</Provider>
   );
-  return render(<FeedPage />, { wrapper });
+  return { ...render(<FeedPage />, { wrapper }), store };
 }
 
 const RESPONSE: FeedResponse = {
@@ -145,26 +152,30 @@ describe("FeedPage", () => {
     );
   });
 
-  it("marks the feed seen on mount", async () => {
-    renderFeed();
+  it("marks the feed seen and clears the badge on mount", async () => {
+    const { store } = renderFeed();
     await waitFor(() => expect(markFeedSeen).toHaveBeenCalledWith(1));
+    // Clearing the badge is the half of this feature the user actually sees,
+    // and it is optimistic — it must not wait on the request above.
+    expect(store.get(feedUnseenCountAtom)).toBe(0);
   });
 
   // Mark-seen lives in its own effect rather than inside `getFeed`'s `.then`,
   // precisely so a failed load cannot leave the sidebar dot stuck on. Folding
   // the two effects together would still pass every other test in this file.
-  it("marks the feed seen even when the fetch fails", async () => {
+  it("marks the feed seen and clears the badge even when the fetch fails", async () => {
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => {});
     getFeed.mockRejectedValue(new Error("boom"));
 
-    renderFeed();
+    const { store } = renderFeed();
 
     // Assert the failure actually surfaced, so this cannot silently degrade
     // into a second copy of the happy-path test.
     await waitFor(() => expect(screen.getByText("boom")).toBeTruthy());
     await waitFor(() => expect(markFeedSeen).toHaveBeenCalledWith(1));
+    expect(store.get(feedUnseenCountAtom)).toBe(0);
 
     consoleError.mockRestore();
   });

--- a/src/components/FeedPage.test.tsx
+++ b/src/components/FeedPage.test.tsx
@@ -12,12 +12,13 @@ import { authTokensAtom } from "../atoms/auth";
 import type { FeedResponse } from "../types";
 
 const getFeed = vi.fn();
+const markFeedSeen = vi.fn();
 const navigateToMix = vi.fn();
 const navigateToAlbum = vi.fn();
 
 vi.mock("../api/tidal", () => ({
   getFeed: (...args: unknown[]) => getFeed(...args),
-  markFeedSeen: vi.fn(() => Promise.resolve()),
+  markFeedSeen: (...args: unknown[]) => markFeedSeen(...args),
 }));
 
 vi.mock("../hooks/useNavigation", () => ({
@@ -97,6 +98,7 @@ describe("FeedPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getFeed.mockResolvedValue(RESPONSE);
+    markFeedSeen.mockResolvedValue(undefined);
   });
 
   it("renders a row per item with a bucket heading", async () => {
@@ -141,5 +143,29 @@ describe("FeedPage", () => {
     await waitFor(() =>
       expect(screen.getByText(/nothing here yet/i)).toBeTruthy(),
     );
+  });
+
+  it("marks the feed seen on mount", async () => {
+    renderFeed();
+    await waitFor(() => expect(markFeedSeen).toHaveBeenCalledWith(1));
+  });
+
+  // Mark-seen lives in its own effect rather than inside `getFeed`'s `.then`,
+  // precisely so a failed load cannot leave the sidebar dot stuck on. Folding
+  // the two effects together would still pass every other test in this file.
+  it("marks the feed seen even when the fetch fails", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    getFeed.mockRejectedValue(new Error("boom"));
+
+    renderFeed();
+
+    // Assert the failure actually surfaced, so this cannot silently degrade
+    // into a second copy of the happy-path test.
+    await waitFor(() => expect(screen.getByText("boom")).toBeTruthy());
+    await waitFor(() => expect(markFeedSeen).toHaveBeenCalledWith(1));
+
+    consoleError.mockRestore();
   });
 });

--- a/src/components/FeedPage.test.tsx
+++ b/src/components/FeedPage.test.tsx
@@ -10,6 +10,7 @@ import {
 import { Provider, createStore } from "jotai";
 import { authTokensAtom } from "../atoms/auth";
 import { feedUnseenCountAtom } from "../atoms/ui";
+import { ToastProvider } from "../contexts/ToastContext";
 import type { FeedResponse } from "../types";
 
 const getFeed = vi.fn();
@@ -17,7 +18,13 @@ const markFeedSeen = vi.fn();
 const navigateToMix = vi.fn();
 const navigateToAlbum = vi.fn();
 
-vi.mock("../api/tidal", () => ({
+// Spread the real module rather than listing exports: opening the row context
+// menu pulls MediaContextMenu in, whose own imports (fetchMediaTracks,
+// AddToPlaylistMenu -> getAllPlaylists, ...) resolve lazily and would be
+// undefined under a partial mock. Same reasoning as
+// ViewAllPage.lovedTracks.test.tsx.
+vi.mock("../api/tidal", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../api/tidal")>()),
   getFeed: (...args: unknown[]) => getFeed(...args),
   markFeedSeen: (...args: unknown[]) => markFeedSeen(...args),
 }));
@@ -45,8 +52,12 @@ function renderFeed() {
   const store = createStore();
   store.set(authTokensAtom, { user_id: 1 } as never);
   store.set(feedUnseenCountAtom, 3);
+  // ToastProvider is required once a row menu opens: MediaContextMenu calls
+  // useToast, which throws outside a provider.
   const wrapper = ({ children }: PropsWithChildren) => (
-    <Provider store={store}>{children}</Provider>
+    <Provider store={store}>
+      <ToastProvider>{children}</ToastProvider>
+    </Provider>
   );
   return { ...render(<FeedPage />, { wrapper }), store };
 }
@@ -142,6 +153,53 @@ describe("FeedPage", () => {
     // Only the mix and album rows carry a play button; the inert one has none.
     // `queryAll` rather than `query`, which throws on more than one match.
     expect(screen.queryAllByLabelText(/^Play /).length).toBe(2);
+  });
+
+  it("opens the context menu from the row's three-dot button", async () => {
+    renderFeed();
+    await waitFor(() => expect(screen.getByText("July 2026")).toBeTruthy());
+
+    fireEvent.click(screen.getByLabelText("More options for Some Single"));
+
+    // "Play now" is MediaContextMenu's first entry, so its presence proves the
+    // real menu mounted rather than a placeholder.
+    await waitFor(() => expect(screen.getByText("Play now")).toBeTruthy());
+  });
+
+  it("opens the context menu on right-click", async () => {
+    renderFeed();
+    await waitFor(() => expect(screen.getByText("July 2026")).toBeTruthy());
+
+    const rows = document.querySelectorAll("div.group");
+    fireEvent.contextMenu(rows[1]);
+
+    await waitFor(() => expect(screen.getByText("Play now")).toBeTruthy());
+  });
+
+  it("does not navigate when the three-dot button is clicked", async () => {
+    renderFeed();
+    await waitFor(() => expect(screen.getByText("July 2026")).toBeTruthy());
+
+    // The button sits inside the row, so without stopPropagation the row's own
+    // click handler would fire and navigate away behind the menu.
+    fireEvent.click(screen.getByLabelText("More options for Some Single"));
+
+    expect(navigateToAlbum).not.toHaveBeenCalled();
+    expect(navigateToMix).not.toHaveBeenCalled();
+  });
+
+  it("gives the unknown row no three-dot button and no menu", async () => {
+    renderFeed();
+    await waitFor(() => expect(screen.getByText("July 2026")).toBeTruthy());
+
+    // Query by title, not by aria-label: the unknown payload has no title, so
+    // its label is "More options for " and Testing Library's whitespace
+    // normalisation trims it — a /^More options for / regex silently stops
+    // matching and the assertion passes even when the button is rendered.
+    expect(screen.queryAllByTitle("More options").length).toBe(2);
+
+    fireEvent.contextMenu(document.querySelectorAll("div.group")[2]);
+    expect(screen.queryByText("Play now")).toBeNull();
   });
 
   it("renders an empty state when there are no items", async () => {

--- a/src/components/FeedPage.test.tsx
+++ b/src/components/FeedPage.test.tsx
@@ -1,6 +1,12 @@
 import type { PropsWithChildren } from "react";
 import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { Provider, createStore } from "jotai";
 import { authTokensAtom } from "../atoms/auth";
 import type { FeedResponse } from "../types";
@@ -110,12 +116,20 @@ describe("FeedPage", () => {
     renderFeed();
     await waitFor(() => expect(screen.getByText("July 2026")).toBeTruthy());
 
-    // The unknown payload has no title of its own, so the row shows the mix and
-    // album rows as clickable and leaves the third inert: exactly two rows carry
-    // the cursor-pointer affordance.
-    const clickable = document.querySelectorAll("div.group.cursor-pointer");
-    expect(clickable.length).toBe(2);
-    // Same two rows carry a play button; the inert one contributes none.
+    // The unknown payload renders no title and no subtitle, so assert the row
+    // count directly: without this the tests would pass just as well against an
+    // implementation that dropped unknown kinds from the list entirely.
+    const rows = document.querySelectorAll("div.group");
+    expect(rows.length).toBe(3);
+
+    // Inertness has to be tested through behaviour, not through a styling class:
+    // a row wired to `handleOpen` but missing `cursor-pointer` would still call
+    // `navigateToAlbum(NaN)` and open a blank page.
+    fireEvent.click(rows[2]);
+    expect(navigateToMix).not.toHaveBeenCalled();
+    expect(navigateToAlbum).not.toHaveBeenCalled();
+
+    // Only the mix and album rows carry a play button; the inert one has none.
     // `queryAll` rather than `query`, which throws on more than one match.
     expect(screen.queryAllByLabelText(/^Play /).length).toBe(2);
   });

--- a/src/components/FeedPage.test.tsx
+++ b/src/components/FeedPage.test.tsx
@@ -1,0 +1,130 @@
+import type { PropsWithChildren } from "react";
+import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { Provider, createStore } from "jotai";
+import { authTokensAtom } from "../atoms/auth";
+import type { FeedResponse } from "../types";
+
+const getFeed = vi.fn();
+const navigateToMix = vi.fn();
+const navigateToAlbum = vi.fn();
+
+vi.mock("../api/tidal", () => ({
+  getFeed: (...args: unknown[]) => getFeed(...args),
+}));
+
+vi.mock("../hooks/useNavigation", () => ({
+  useNavigation: () => ({ navigateToMix, navigateToAlbum }),
+}));
+
+const playMedia = vi.fn();
+
+vi.mock("../hooks/useMediaPlay", () => ({
+  useMediaPlay: () => playMedia,
+}));
+
+import FeedPage from "./FeedPage";
+
+/** FeedPage reads the user id from `authTokensAtom` and bails when it is absent,
+ *  so every render needs a store with one set — the default atom value is null. */
+function renderFeed() {
+  const store = createStore();
+  store.set(authTokensAtom, { user_id: 1 } as never);
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <Provider store={store}>{children}</Provider>
+  );
+  return render(<FeedPage />, { wrapper });
+}
+
+const RESPONSE: FeedResponse = {
+  unseenCount: 0,
+  items: [
+    {
+      kind: "mix",
+      activityType: "NEW_HISTORY_MIX",
+      occurredAt: "2026-08-01T00:00:00.000Z",
+      seen: true,
+      item: {
+        id: "0011112222333344445555666677",
+        mixType: "HISTORY_MONTHLY_MIX",
+        title: "July 2026",
+        subTitle: "Some Artist and more",
+        images: {
+          MEDIUM: {
+            width: 533,
+            height: 533,
+            url: "https://example.invalid/a.jpg",
+          },
+        },
+      },
+    },
+    {
+      kind: "album",
+      activityType: "NEW_ALBUM_RELEASE",
+      occurredAt: "2026-06-05T00:00:00.000Z",
+      seen: true,
+      item: {
+        id: 1234,
+        title: "Some Single",
+        type: "SINGLE",
+        cover: "00000000-1111-2222-3333-444444444444",
+        artists: [{ id: 9, name: "Some Artist" }],
+      },
+    },
+    {
+      kind: "unknown",
+      activityType: "NEW_MYSTERY_THING",
+      occurredAt: "2026-01-01T00:00:00.000Z",
+      seen: true,
+      item: { id: 7 },
+    },
+  ],
+};
+
+describe("FeedPage", () => {
+  // There is no vitest setup file, so RTL's automatic cleanup is never
+  // registered: without this each render stacks in document.body and the
+  // single-match queries below find duplicates from earlier tests.
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getFeed.mockResolvedValue(RESPONSE);
+  });
+
+  it("renders a row per item with a bucket heading", async () => {
+    renderFeed();
+    await waitFor(() => expect(screen.getByText("July 2026")).toBeTruthy());
+    expect(screen.getByText("Some Single")).toBeTruthy();
+  });
+
+  it("never emits an empty image src", async () => {
+    const { container } = renderFeed();
+    await waitFor(() => expect(screen.getByText("July 2026")).toBeTruthy());
+    for (const img of Array.from(container.querySelectorAll("img"))) {
+      expect(img.getAttribute("src")).toBeTruthy();
+    }
+  });
+
+  it("renders the unknown row without making it clickable", async () => {
+    renderFeed();
+    await waitFor(() => expect(screen.getByText("July 2026")).toBeTruthy());
+
+    // The unknown payload has no title of its own, so the row shows the mix and
+    // album rows as clickable and leaves the third inert: exactly two rows carry
+    // the cursor-pointer affordance.
+    const clickable = document.querySelectorAll("div.group.cursor-pointer");
+    expect(clickable.length).toBe(2);
+    // Same two rows carry a play button; the inert one contributes none.
+    // `queryAll` rather than `query`, which throws on more than one match.
+    expect(screen.queryAllByLabelText(/^Play /).length).toBe(2);
+  });
+
+  it("renders an empty state when there are no items", async () => {
+    getFeed.mockResolvedValue({ items: [], unseenCount: 0 });
+    renderFeed();
+    await waitFor(() =>
+      expect(screen.getByText(/nothing here yet/i)).toBeTruthy(),
+    );
+  });
+});

--- a/src/components/FeedPage.test.tsx
+++ b/src/components/FeedPage.test.tsx
@@ -152,7 +152,10 @@ describe("FeedPage", () => {
 
     // Only the mix and album rows carry a play button; the inert one has none.
     // `queryAll` rather than `query`, which throws on more than one match.
-    expect(screen.queryAllByLabelText(/^Play /).length).toBe(2);
+    // `\b` not a trailing space: the unknown row has no title, so a leaked
+    // button would be labelled "Play ", which Testing Library trims to "Play"
+    // — and `/^Play /` would silently stop matching it.
+    expect(screen.queryAllByLabelText(/^Play\b/).length).toBe(2);
   });
 
   it("opens the context menu from the row's three-dot button", async () => {
@@ -170,8 +173,12 @@ describe("FeedPage", () => {
     renderFeed();
     await waitFor(() => expect(screen.getByText("July 2026")).toBeTruthy());
 
+    // rows[0] is the mix row — bucket order is This month / Last month / Older
+    // and `groupFeedByPeriod` preserves input order, so the mix is always
+    // first regardless of the date the suite runs. The dots-button test above
+    // covers the album row, so between them both kinds are exercised.
     const rows = document.querySelectorAll("div.group");
-    fireEvent.contextMenu(rows[1]);
+    fireEvent.contextMenu(rows[0]);
 
     await waitFor(() => expect(screen.getByText("Play now")).toBeTruthy());
   });

--- a/src/components/FeedPage.test.tsx
+++ b/src/components/FeedPage.test.tsx
@@ -17,6 +17,7 @@ const navigateToAlbum = vi.fn();
 
 vi.mock("../api/tidal", () => ({
   getFeed: (...args: unknown[]) => getFeed(...args),
+  markFeedSeen: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock("../hooks/useNavigation", () => ({

--- a/src/components/FeedPage.tsx
+++ b/src/components/FeedPage.tsx
@@ -28,9 +28,10 @@ function feedSubtitle(entry: FeedItem): string {
           .join(", ")
       : "";
     const rawType = typeof entry.item?.type === "string" ? entry.item.type : "";
-    const label = rawType
-      ? rawType.charAt(0) + rawType.slice(1).toLowerCase()
-      : "";
+    const label =
+      rawType === "EP"
+        ? "EP"
+        : rawType.charAt(0) + rawType.slice(1).toLowerCase();
     if (label && artists) return `${label} by ${artists}`;
     if (artists) return artists;
   }

--- a/src/components/FeedPage.tsx
+++ b/src/components/FeedPage.tsx
@@ -1,0 +1,13 @@
+import PageContainer from "./PageContainer";
+
+export default function FeedPage() {
+  return (
+    <div className="flex-1 bg-gradient-to-b from-th-surface to-th-base min-h-full">
+      <PageContainer className="px-8 py-10">
+        <h1 className="text-[32px] font-bold text-th-text-primary tracking-tight mb-10">
+          Feed
+        </h1>
+      </PageContainer>
+    </div>
+  );
+}

--- a/src/components/FeedPage.tsx
+++ b/src/components/FeedPage.tsx
@@ -1,12 +1,190 @@
+import { useState, useEffect, useMemo, type MouseEvent } from "react";
+import { useAtomValue } from "jotai";
+import { Music, Play } from "lucide-react";
+import { getFeed } from "../api/tidal";
+import { authTokensAtom } from "../atoms/auth";
+import { safeErrorMessage } from "../lib/errorUtils";
+import { groupFeedByPeriod } from "../lib/feedGrouping";
+import {
+  buildMediaItem,
+  getItemImage,
+  getItemSubtitle,
+  getItemTitle,
+} from "../utils/itemHelpers";
+import { useMediaPlay } from "../hooks/useMediaPlay";
+import { useNavigation } from "../hooks/useNavigation";
+import type { FeedItem } from "../types";
+import { MediaGridError, MediaGridEmpty } from "./MediaGrid";
 import PageContainer from "./PageContainer";
 
+/** Album rows read "Single by Artist" / "Album by Artist"; everything else
+ *  falls back to the shared subtitle helper. */
+function feedSubtitle(entry: FeedItem): string {
+  if (entry.kind === "album") {
+    const artists = Array.isArray(entry.item?.artists)
+      ? (entry.item.artists as Array<{ name?: string }>)
+          .map((a) => a.name)
+          .filter(Boolean)
+          .join(", ")
+      : "";
+    const rawType = typeof entry.item?.type === "string" ? entry.item.type : "";
+    const label = rawType
+      ? rawType.charAt(0) + rawType.slice(1).toLowerCase()
+      : "";
+    if (label && artists) return `${label} by ${artists}`;
+    if (artists) return artists;
+  }
+  return getItemSubtitle(entry.item);
+}
+
+function FeedRow({ entry }: { entry: FeedItem }) {
+  const { navigateToMix, navigateToAlbum } = useNavigation();
+  const playMedia = useMediaPlay();
+
+  const image = getItemImage(entry.item, 160);
+  const title = getItemTitle(entry.item);
+  const subtitle = feedSubtitle(entry);
+  const isInert = entry.kind === "unknown";
+
+  const handleOpen = () => {
+    if (entry.kind === "mix") {
+      navigateToMix(String(entry.item.id), {
+        title,
+        image: image || undefined,
+        subtitle,
+        mixType: entry.item.mixType,
+      });
+    } else if (entry.kind === "album") {
+      navigateToAlbum(Number(entry.item.id), {
+        title,
+        cover: entry.item.cover,
+      });
+    }
+  };
+
+  const handlePlay = (e: MouseEvent) => {
+    e.stopPropagation();
+    const media = buildMediaItem(entry.item);
+    if (media) playMedia(media);
+  };
+
+  return (
+    <div
+      onClick={isInert ? undefined : handleOpen}
+      className={`group flex items-center gap-4 px-2 py-2 rounded-md transition-colors duration-150 ${
+        isInert ? "" : "cursor-pointer hover:bg-th-surface-hover"
+      }`}
+    >
+      <div className="relative w-14 h-14 shrink-0 rounded-md overflow-hidden bg-th-surface-hover shadow">
+        {image ? (
+          <img
+            src={image}
+            alt={title}
+            className="w-full h-full object-cover"
+            loading="lazy"
+            onError={(e) => {
+              (e.target as HTMLImageElement).style.display = "none";
+            }}
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-th-button to-th-surface">
+            <Music size={20} className="text-th-text-faint" />
+          </div>
+        )}
+        {!isInert && (
+          <>
+            <div className="absolute inset-0 bg-black/30 opacity-0 group-hover:opacity-100 transition-opacity duration-200" />
+            <button
+              onClick={handlePlay}
+              aria-label={`Play ${title}`}
+              className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-200 cursor-pointer"
+            >
+              <Play size={20} fill="white" className="text-white ml-0.5" />
+            </button>
+          </>
+        )}
+      </div>
+
+      <div className="min-w-0">
+        <div className="text-sm font-semibold text-th-text-primary truncate">
+          {title}
+        </div>
+        {subtitle && (
+          <div className="text-sm text-th-text-secondary truncate">
+            {subtitle}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export default function FeedPage() {
+  const userId = useAtomValue(authTokensAtom)?.user_id;
+
+  const [items, setItems] = useState<FeedItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!userId) return;
+
+    let active = true;
+
+    getFeed(userId)
+      .then((feed) => {
+        if (!active) return;
+        setItems(feed.items);
+        setError(null);
+      })
+      .catch((err) => {
+        console.error("[FeedPage] Failed:", err);
+        if (!active) return;
+        setError(safeErrorMessage(err, "Failed to load feed"));
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [userId]);
+
+  const groups = useMemo(() => groupFeedByPeriod(items, new Date()), [items]);
+
   return (
     <div className="flex-1 bg-gradient-to-b from-th-surface to-th-base min-h-full">
       <PageContainer className="px-8 py-10">
         <h1 className="text-[32px] font-bold text-th-text-primary tracking-tight mb-10">
           Feed
         </h1>
+
+        {error && <MediaGridError error={error} />}
+
+        {!loading && !error && groups.length === 0 && (
+          <MediaGridEmpty message="Nothing here yet" />
+        )}
+
+        {!error && groups.length > 0 && (
+          <div className="space-y-8">
+            {groups.map((group) => (
+              <section key={group.label}>
+                <h2 className="text-sm font-semibold text-th-text-secondary mb-3">
+                  {group.label}
+                </h2>
+                <div className="space-y-1">
+                  {group.items.map((entry, idx) => (
+                    <FeedRow
+                      key={`${entry.occurredAt}-${entry.kind}-${idx}`}
+                      entry={entry}
+                    />
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        )}
       </PageContainer>
     </div>
   );

--- a/src/components/FeedPage.tsx
+++ b/src/components/FeedPage.tsx
@@ -14,7 +14,7 @@ import {
 } from "../utils/itemHelpers";
 import { useMediaPlay } from "../hooks/useMediaPlay";
 import { useNavigation } from "../hooks/useNavigation";
-import type { FeedItem } from "../types";
+import type { FeedItem, MediaItemType } from "../types";
 import MediaContextMenu from "./MediaContextMenu";
 import { MediaGridError, MediaGridEmpty } from "./MediaGrid";
 import PageContainer from "./PageContainer";
@@ -40,7 +40,15 @@ function feedSubtitle(entry: FeedItem): string {
   return getItemSubtitle(entry.item);
 }
 
-function FeedRow({ entry }: { entry: FeedItem }) {
+function FeedRow({
+  entry,
+  menuOpen,
+  onOpenMenu,
+}: {
+  entry: FeedItem;
+  menuOpen: boolean;
+  onOpenMenu: (item: MediaItemType, position: { x: number; y: number }) => void;
+}) {
   const { navigateToMix, navigateToAlbum } = useNavigation();
   const playMedia = useMediaPlay();
 
@@ -53,14 +61,21 @@ function FeedRow({ entry }: { entry: FeedItem }) {
   // on a null return: `buildMediaItem` falls through to its `item.id &&
   // !isTrackItem` branch for an unrecognised payload and hands back a bogus
   // album, so the kind check is the only thing that keeps unknown rows inert.
+  // The type hint keeps this deterministic: without it `buildMediaItem`
+  // re-sniffs the payload via `isMixItem` (which keys on `mixType`), a
+  // different signal from the `historyMix` payload key the backend derives
+  // `kind` from. A mix arriving without `mixType` would otherwise fall into
+  // the same album branch that already caught us on unknown rows.
   const mediaItem = useMemo(
-    () => (isInert ? null : buildMediaItem(entry.item)),
-    [isInert, entry.item],
+    () =>
+      isInert
+        ? null
+        : buildMediaItem(
+            entry.item,
+            entry.kind === "mix" ? "MIX_LIST" : "ALBUM_LIST",
+          ),
+    [isInert, entry.kind, entry.item],
   );
-  const [menuPosition, setMenuPosition] = useState<{
-    x: number;
-    y: number;
-  } | null>(null);
 
   const handleOpen = () => {
     if (entry.kind === "mix") {
@@ -87,7 +102,7 @@ function FeedRow({ entry }: { entry: FeedItem }) {
     if (!mediaItem) return;
     e.preventDefault();
     e.stopPropagation();
-    setMenuPosition({ x: e.clientX, y: e.clientY });
+    onOpenMenu(mediaItem, { x: e.clientX, y: e.clientY });
   };
 
   return (
@@ -146,21 +161,13 @@ function FeedRow({ entry }: { entry: FeedItem }) {
           aria-label={`More options for ${title}`}
           title="More options"
           className={`shrink-0 p-1.5 rounded-full transition-colors cursor-pointer ${
-            menuPosition
+            menuOpen
               ? "text-th-text-primary opacity-100"
               : "text-th-text-muted hover:text-th-text-primary opacity-0 group-hover:opacity-100"
           }`}
         >
           <MoreHorizontal size={18} />
         </button>
-      )}
-
-      {menuPosition && mediaItem && (
-        <MediaContextMenu
-          item={mediaItem}
-          cursorPosition={menuPosition}
-          onClose={() => setMenuPosition(null)}
-        />
       )}
     </div>
   );
@@ -211,6 +218,17 @@ export default function FeedPage() {
 
   const groups = useMemo(() => groupFeedByPeriod(items, new Date()), [items]);
 
+  // Held here, not in FeedRow: MediaContextMenu renders through a portal, and
+  // React portals bubble events up the REACT tree. Nested inside a row, a click
+  // dismissing one of its sub-modals (Add to playlist -> Create playlist ->
+  // backdrop) would reach the row's onClick and navigate. Every other
+  // MediaContextMenu call site renders at container level for the same reason.
+  const [contextMenu, setContextMenu] = useState<{
+    rowKey: string;
+    item: MediaItemType;
+    position: { x: number; y: number };
+  } | null>(null);
+
   return (
     <div className="flex-1 bg-gradient-to-b from-th-surface to-th-base min-h-full">
       <PageContainer className="px-8 py-10">
@@ -232,18 +250,33 @@ export default function FeedPage() {
                   {group.label}
                 </h2>
                 <div className="space-y-1">
-                  {group.items.map((entry, idx) => (
-                    <FeedRow
-                      key={`${entry.occurredAt}-${entry.kind}-${idx}`}
-                      entry={entry}
-                    />
-                  ))}
+                  {group.items.map((entry, idx) => {
+                    const rowKey = `${entry.occurredAt}-${entry.kind}-${idx}`;
+                    return (
+                      <FeedRow
+                        key={rowKey}
+                        entry={entry}
+                        menuOpen={contextMenu?.rowKey === rowKey}
+                        onOpenMenu={(item, position) =>
+                          setContextMenu({ rowKey, item, position })
+                        }
+                      />
+                    );
+                  })}
                 </div>
               </section>
             ))}
           </div>
         )}
       </PageContainer>
+
+      {contextMenu && (
+        <MediaContextMenu
+          item={contextMenu.item}
+          cursorPosition={contextMenu.position}
+          onClose={() => setContextMenu(null)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/FeedPage.tsx
+++ b/src/components/FeedPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, type MouseEvent } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
-import { Music, Play } from "lucide-react";
+import { MoreHorizontal, Music, Play } from "lucide-react";
 import { getFeed, markFeedSeen } from "../api/tidal";
 import { authTokensAtom } from "../atoms/auth";
 import { feedUnseenCountAtom } from "../atoms/ui";
@@ -15,6 +15,7 @@ import {
 import { useMediaPlay } from "../hooks/useMediaPlay";
 import { useNavigation } from "../hooks/useNavigation";
 import type { FeedItem } from "../types";
+import MediaContextMenu from "./MediaContextMenu";
 import { MediaGridError, MediaGridEmpty } from "./MediaGrid";
 import PageContainer from "./PageContainer";
 
@@ -48,6 +49,19 @@ function FeedRow({ entry }: { entry: FeedItem }) {
   const subtitle = feedSubtitle(entry);
   const isInert = entry.kind === "unknown";
 
+  // Drives playback and the context menu alike. Gated on `isInert` rather than
+  // on a null return: `buildMediaItem` falls through to its `item.id &&
+  // !isTrackItem` branch for an unrecognised payload and hands back a bogus
+  // album, so the kind check is the only thing that keeps unknown rows inert.
+  const mediaItem = useMemo(
+    () => (isInert ? null : buildMediaItem(entry.item)),
+    [isInert, entry.item],
+  );
+  const [menuPosition, setMenuPosition] = useState<{
+    x: number;
+    y: number;
+  } | null>(null);
+
   const handleOpen = () => {
     if (entry.kind === "mix") {
       navigateToMix(String(entry.item.id), {
@@ -66,13 +80,20 @@ function FeedRow({ entry }: { entry: FeedItem }) {
 
   const handlePlay = (e: MouseEvent) => {
     e.stopPropagation();
-    const media = buildMediaItem(entry.item);
-    if (media) playMedia(media);
+    if (mediaItem) playMedia(mediaItem);
+  };
+
+  const openMenu = (e: MouseEvent) => {
+    if (!mediaItem) return;
+    e.preventDefault();
+    e.stopPropagation();
+    setMenuPosition({ x: e.clientX, y: e.clientY });
   };
 
   return (
     <div
       onClick={isInert ? undefined : handleOpen}
+      onContextMenu={openMenu}
       className={`group flex items-center gap-4 px-2 py-2 rounded-md transition-colors duration-150 ${
         isInert ? "" : "cursor-pointer hover:bg-th-surface-hover"
       }`}
@@ -107,7 +128,8 @@ function FeedRow({ entry }: { entry: FeedItem }) {
         )}
       </div>
 
-      <div className="min-w-0">
+      {/* flex-1 so the trailing menu button is pushed to the far right */}
+      <div className="flex-1 min-w-0">
         <div className="text-sm font-semibold text-th-text-primary truncate">
           {title}
         </div>
@@ -117,6 +139,29 @@ function FeedRow({ entry }: { entry: FeedItem }) {
           </div>
         )}
       </div>
+
+      {mediaItem && (
+        <button
+          onClick={openMenu}
+          aria-label={`More options for ${title}`}
+          title="More options"
+          className={`shrink-0 p-1.5 rounded-full transition-colors cursor-pointer ${
+            menuPosition
+              ? "text-th-text-primary opacity-100"
+              : "text-th-text-muted hover:text-th-text-primary opacity-0 group-hover:opacity-100"
+          }`}
+        >
+          <MoreHorizontal size={18} />
+        </button>
+      )}
+
+      {menuPosition && mediaItem && (
+        <MediaContextMenu
+          item={mediaItem}
+          cursorPosition={menuPosition}
+          onClose={() => setMenuPosition(null)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/FeedPage.tsx
+++ b/src/components/FeedPage.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useMemo, type MouseEvent } from "react";
-import { useAtomValue } from "jotai";
+import { useAtomValue, useSetAtom } from "jotai";
 import { Music, Play } from "lucide-react";
-import { getFeed } from "../api/tidal";
+import { getFeed, markFeedSeen } from "../api/tidal";
 import { authTokensAtom } from "../atoms/auth";
+import { feedUnseenCountAtom } from "../atoms/ui";
 import { safeErrorMessage } from "../lib/errorUtils";
 import { groupFeedByPeriod } from "../lib/feedGrouping";
 import {
@@ -122,6 +123,7 @@ function FeedRow({ entry }: { entry: FeedItem }) {
 
 export default function FeedPage() {
   const userId = useAtomValue(authTokensAtom)?.user_id;
+  const setUnseenCount = useSetAtom(feedUnseenCountAtom);
 
   const [items, setItems] = useState<FeedItem[]>([]);
   const [loading, setLoading] = useState(true);
@@ -151,6 +153,16 @@ export default function FeedPage() {
       active = false;
     };
   }, [userId]);
+
+  // Separate from the fetch: opening the page is what marks the feed seen, so
+  // this must fire even when the list fails to load.
+  useEffect(() => {
+    if (!userId) return;
+    setUnseenCount(0);
+    markFeedSeen(userId).catch((err) =>
+      console.error("[FeedPage] mark seen failed:", err),
+    );
+  }, [userId, setUnseenCount]);
 
   const groups = useMemo(() => groupFeedByPeriod(items, new Date()), [items]);
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import {
   Home,
   Compass,
+  Bell,
   Library,
   Heart,
   Music,
@@ -60,7 +61,7 @@ import {
   renamedFoldersAtom,
   updatedPlaylistsAtom,
 } from "../atoms/playlists";
-import { sidebarCollapsedAtom } from "../atoms/ui";
+import { sidebarCollapsedAtom, feedUnseenCountAtom } from "../atoms/ui";
 import { currentViewAtom } from "../atoms/navigation";
 
 export default function Sidebar() {
@@ -72,10 +73,12 @@ export default function Sidebar() {
     navigateToFavorites,
     navigateHome,
     navigateToExplore,
+    navigateToFeed,
     navigateToLibraryViewAll,
     navigateToPlaylistFolder,
   } = useNavigation();
   const currentView = useAtomValue(currentViewAtom);
+  const feedUnseenCount = useAtomValue(feedUnseenCountAtom);
   const { authTokens } = useAuth();
   const [isCollapsed, setIsCollapsed] = useAtom(sidebarCollapsedAtom);
   const [activeFilter, setActiveFilter] = useState<
@@ -451,6 +454,23 @@ export default function Sidebar() {
           {!isCollapsed && (
             <span className="font-semibold text-sm">Explore</span>
           )}
+        </button>
+        <button
+          onClick={navigateToFeed}
+          className={`relative w-full flex items-center gap-3 px-2.5 py-2.5 rounded-md transition-colors duration-150 group ${
+            currentView.type === "feed"
+              ? "text-th-text-primary bg-th-hl-med"
+              : "text-th-text-secondary hover:text-th-text-primary hover:bg-th-border-subtle"
+          } ${isCollapsed ? "justify-center px-0" : ""}`}
+          title="Feed"
+        >
+          <span className="relative">
+            <Bell size={20} strokeWidth={2} />
+            {feedUnseenCount > 0 && (
+              <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-th-accent ring-2 ring-th-base" />
+            )}
+          </span>
+          {!isCollapsed && <span className="font-semibold text-sm">Feed</span>}
         </button>
       </nav>
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -467,7 +467,7 @@ export default function Sidebar() {
           <span className="relative">
             <Bell size={20} strokeWidth={2} />
             {feedUnseenCount > 0 && (
-              <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-th-accent ring-2 ring-th-base" />
+              <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-th-accent ring-2 ring-th-sidebar" />
             )}
           </span>
           {!isCollapsed && <span className="font-semibold text-sm">Feed</span>}

--- a/src/hooks/useNavigation.ts
+++ b/src/hooks/useNavigation.ts
@@ -132,6 +132,10 @@ export function useNavigation() {
     [navigate],
   );
 
+  const navigateToFeed = useCallback(() => {
+    navigate({ type: "feed" });
+  }, [navigate]);
+
   const navigateToLibraryViewAll = useCallback(
     (libraryType: "playlists" | "albums" | "artists" | "mixes") => {
       navigate({ type: "libraryViewAll", libraryType });
@@ -165,6 +169,7 @@ export function useNavigation() {
     navigateToProfilePlaylists,
     navigateToExplore,
     navigateToExplorePage,
+    navigateToFeed,
     navigateToLibraryViewAll,
     navigateToPlaylistFolder,
   };

--- a/src/lib/feedGrouping.test.ts
+++ b/src/lib/feedGrouping.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { groupFeedByPeriod } from "./feedGrouping";
+import type { FeedItem } from "../types";
+
+function item(occurredAt: string): FeedItem {
+  return {
+    kind: "album",
+    activityType: "NEW_ALBUM_RELEASE",
+    occurredAt,
+    seen: true,
+    item: { id: 1, title: "x" },
+  };
+}
+
+describe("groupFeedByPeriod", () => {
+  it("returns no groups for an empty list", () => {
+    expect(groupFeedByPeriod([], new Date("2026-08-22T12:00:00Z"))).toEqual([]);
+  });
+
+  it("buckets the current calendar month as This month", () => {
+    const groups = groupFeedByPeriod(
+      [item("2026-08-01T00:00:00.000Z")],
+      new Date("2026-08-22T12:00:00Z"),
+    );
+    expect(groups).toHaveLength(1);
+    expect(groups[0].label).toBe("This month");
+  });
+
+  it("buckets the preceding calendar month as Last month", () => {
+    const groups = groupFeedByPeriod(
+      [item("2026-07-15T00:00:00.000Z")],
+      new Date("2026-08-22T12:00:00Z"),
+    );
+    expect(groups[0].label).toBe("Last month");
+  });
+
+  it("treats December as Last month when now is January", () => {
+    const groups = groupFeedByPeriod(
+      [item("2025-12-20T00:00:00.000Z")],
+      new Date("2026-01-10T12:00:00Z"),
+    );
+    expect(groups[0].label).toBe("Last month");
+  });
+
+  it("buckets anything earlier as Older", () => {
+    const groups = groupFeedByPeriod(
+      [item("2026-05-01T00:00:00.000Z")],
+      new Date("2026-08-22T12:00:00Z"),
+    );
+    expect(groups[0].label).toBe("Older");
+  });
+
+  it("puts future-dated entries in This month", () => {
+    const groups = groupFeedByPeriod(
+      [item("2027-01-01T00:00:00.000Z")],
+      new Date("2026-08-22T12:00:00Z"),
+    );
+    expect(groups[0].label).toBe("This month");
+  });
+
+  it("omits empty buckets and keeps bucket order", () => {
+    const groups = groupFeedByPeriod(
+      [item("2026-05-01T00:00:00.000Z"), item("2026-08-02T00:00:00.000Z")],
+      new Date("2026-08-22T12:00:00Z"),
+    );
+    expect(groups.map((g) => g.label)).toEqual(["This month", "Older"]);
+  });
+
+  it("preserves input order within a bucket", () => {
+    const groups = groupFeedByPeriod(
+      [item("2026-08-10T00:00:00.000Z"), item("2026-08-02T00:00:00.000Z")],
+      new Date("2026-08-22T12:00:00Z"),
+    );
+    expect(groups[0].items.map((i) => i.occurredAt)).toEqual([
+      "2026-08-10T00:00:00.000Z",
+      "2026-08-02T00:00:00.000Z",
+    ]);
+  });
+
+  it("drops entries with an unparseable date", () => {
+    expect(
+      groupFeedByPeriod([item("not-a-date")], new Date("2026-08-22T12:00:00Z")),
+    ).toEqual([]);
+  });
+});

--- a/src/lib/feedGrouping.ts
+++ b/src/lib/feedGrouping.ts
@@ -1,0 +1,54 @@
+import type { FeedItem } from "../types";
+
+/** Not exported: `knip` flags exports unused outside their own file, and this feature
+ *  must not add to the baseline count. Consumers infer the shape from the return type. */
+interface FeedGroup {
+  label: string;
+  items: FeedItem[];
+}
+
+const THIS_MONTH = "This month";
+const LAST_MONTH = "Last month";
+const OLDER = "Older";
+
+/**
+ * Bucket feed items by calendar month, not by rolling day counts. A December
+ * entry viewed in January is "Last month", not "Older".
+ *
+ * `now` is a parameter so month and year boundaries are testable without
+ * mocking the clock.
+ *
+ * Both sides are compared in UTC. `occurredAt` is always midnight UTC — a
+ * day-granularity event — so reading it with local getters would shift every
+ * entry back a day in any negative-offset timezone and misbucket the first of
+ * the month. Comparing local-to-local would make the tests timezone-dependent.
+ *
+ * Note that a mix titled "July 2026" carries an `occurredAt` of 2026-08-01, so
+ * in August it lands under "This month". The title and the bucket legitimately
+ * disagree — the reference client behaves the same way.
+ */
+export function groupFeedByPeriod(items: FeedItem[], now: Date): FeedGroup[] {
+  const buckets: Record<string, FeedItem[]> = {
+    [THIS_MONTH]: [],
+    [LAST_MONTH]: [],
+    [OLDER]: [],
+  };
+
+  const nowMonths = now.getUTCFullYear() * 12 + now.getUTCMonth();
+
+  for (const entry of items) {
+    const date = new Date(entry.occurredAt);
+    if (Number.isNaN(date.getTime())) continue;
+
+    const months = date.getUTCFullYear() * 12 + date.getUTCMonth();
+    const delta = nowMonths - months;
+
+    if (delta <= 0) buckets[THIS_MONTH].push(entry);
+    else if (delta === 1) buckets[LAST_MONTH].push(entry);
+    else buckets[OLDER].push(entry);
+  }
+
+  return [THIS_MONTH, LAST_MONTH, OLDER]
+    .filter((label) => buckets[label].length > 0)
+    .map((label) => ({ label, items: buckets[label] }));
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -736,6 +736,27 @@ export interface AlbumPageCached {
   isStale: boolean;
 }
 
+// ==================== Feed ====================
+
+/** @public */
+export type FeedItemKind = "mix" | "album" | "unknown";
+
+export interface FeedItem {
+  kind: FeedItemKind;
+  activityType: string;
+  /** ISO-8601 with milliseconds and a Z suffix, e.g. "2026-08-01T00:00:00.000Z". */
+  occurredAt: string;
+  seen: boolean;
+  /** Raw payload — feed rows render it through the existing item helpers. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  item: any;
+}
+
+export interface FeedResponse {
+  items: FeedItem[];
+  unseenCount: number;
+}
+
 // ==================== Playlist Folders (v2/my-collection/playlists/folders) ====================
 
 export interface PlaylistFoldersResponse {

--- a/src/types.ts
+++ b/src/types.ts
@@ -257,6 +257,7 @@ type ViewTarget =
       };
     }
   | { type: "explore" }
+  | { type: "feed" }
   | { type: "explorePage"; apiPath: string; title: string }
   | {
       type: "artistTracks";


### PR DESCRIPTION
Adds a Feed page — a bell entry in the side panel below Explore, opening a list of activity notifications (new releases from artists you follow, and the monthly "My Most Listened" mixes) grouped into This month / Last month / Older. Rows open the mix or album, hover plays it, and an unread dot on the side-panel button clears when the page is opened.

## Problems / risks

- **Two endpoints are unverified against a live session.** The GET path was inferred from a single browser capture taken against a different host, and the mark-seen PUT comes from 2020-era reverse engineering. Neither has been run from this code — the app is single-instance and a dev instance was already running, so the gate could not be executed here. Both need one manual pass before this is considered done.
- **If the mark-seen PUT no longer exists, the unread dot will clear for the session and return on every launch.** The cache is invalidated unconditionally, so the next fetch re-reads the server's unchanged count. The fallback is to drop the mark-seen call and ship the dot read-only — a two-line change.
- **A silent upstream shape change reads as an empty feed.** A renamed envelope key parses to zero items and a renamed `occurredAt` gets every row dropped by the date grouper; both render "Nothing here yet" with no error. Worth knowing when diagnosing.
- **"Last month" now means two different things in the app.** The feed buckets by calendar month; `TrackList` already labelled tracks "Last month" on rolling 15-30 day thresholds. The feed's semantics match the reference client, so `TrackList` is the side that should change — not included here.
