### PR TITLE
fix(window): restore maximized state and isolate titlebar controls from drag region

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -538,7 +538,8 @@ pub fn run() {
             tauri_plugin_window_state::Builder::default()
                 .with_state_flags(
                     tauri_plugin_window_state::StateFlags::POSITION
-                        | tauri_plugin_window_state::StateFlags::SIZE,
+                        | tauri_plugin_window_state::StateFlags::SIZE
+                        | tauri_plugin_window_state::StateFlags::MAXIMIZED,
                 )
                 .build(),
         )

--- a/src/components/TitleBar.test.tsx
+++ b/src/components/TitleBar.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, cleanup, fireEvent, waitFor } from "@testing-library/react";
+
+const {
+  isMaximized,
+  isFocused,
+  onResized,
+  onFocusChanged,
+  minimize,
+  maximize,
+  unmaximize,
+  close,
+} = vi.hoisted(() => ({
+  isMaximized: vi.fn(),
+  isFocused: vi.fn(),
+  onResized: vi.fn(),
+  onFocusChanged: vi.fn(),
+  minimize: vi.fn(),
+  maximize: vi.fn(),
+  unmaximize: vi.fn(),
+  close: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    isMaximized,
+    isFocused,
+    onResized,
+    onFocusChanged,
+    minimize,
+    maximize,
+    unmaximize,
+    close,
+  }),
+}));
+
+import TitleBar from "./TitleBar";
+
+describe("TitleBar", () => {
+  beforeEach(() => {
+    cleanup();
+    isMaximized.mockReset().mockResolvedValue(false);
+    isFocused.mockReset().mockResolvedValue(true);
+    minimize.mockReset().mockResolvedValue(undefined);
+    maximize.mockReset().mockResolvedValue(undefined);
+    unmaximize.mockReset().mockResolvedValue(undefined);
+    close.mockReset().mockResolvedValue(undefined);
+    onResized.mockReset().mockReturnValue(Promise.resolve(() => {}));
+    onFocusChanged.mockReset().mockReturnValue(Promise.resolve(() => {}));
+  });
+
+  it("renders titlebar with SONE title", async () => {
+    const { getByText } = render(<TitleBar />);
+    expect(getByText("SONE")).toBeDefined();
+  });
+
+  it("keeps controls outside the root drag-region", async () => {
+    const { container, getByRole } = render(<TitleBar />);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.getAttribute("data-tauri-drag-region")).toBeNull();
+
+    const maxBtn = getByRole("button", { name: /maximize/i });
+    expect(maxBtn.closest("[data-tauri-drag-region]")).toBeNull();
+  });
+
+  it("triggers minimize on minimize button click", async () => {
+    const { getByRole } = render(<TitleBar />);
+    const minBtn = getByRole("button", { name: /minimize/i });
+    fireEvent.click(minBtn);
+    expect(minimize).toHaveBeenCalledTimes(1);
+  });
+
+  it("toggles maximize when unmaximized", async () => {
+    isMaximized.mockResolvedValue(false);
+    const { getByRole } = render(<TitleBar />);
+    const maxBtn = getByRole("button", { name: /maximize/i });
+
+    fireEvent.click(maxBtn);
+    await waitFor(() => {
+      expect(maximize).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("toggles unmaximize when already maximized", async () => {
+    isMaximized.mockResolvedValue(true);
+    const { getByRole } = render(<TitleBar />);
+
+    await waitFor(() => {
+      expect(getByRole("button", { name: /restore/i })).toBeDefined();
+    });
+
+    const restoreBtn = getByRole("button", { name: /restore/i });
+    fireEvent.click(restoreBtn);
+
+    await waitFor(() => {
+      expect(unmaximize).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("triggers close on close button click", async () => {
+    const { getByRole } = render(<TitleBar />);
+    const closeBtn = getByRole("button", { name: /close/i });
+    fireEvent.click(closeBtn);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -77,7 +77,6 @@ export default function TitleBar() {
 
   return (
     <div
-      data-tauri-drag-region
       onDoubleClick={handleDoubleClick}
       className="flex items-center justify-between bg-th-overlay border-b border-th-border-subtle select-none shrink-0"
       style={{ height: TITLEBAR_HEIGHT }}
@@ -117,7 +116,11 @@ export default function TitleBar() {
       >
         <button
           data-titlebar-button
-          onClick={minimize}
+          onClick={(e) => {
+            e.stopPropagation();
+            minimize();
+          }}
+          onMouseDown={(e) => e.stopPropagation()}
           aria-label="Minimize"
           className="w-7 h-7 rounded-full flex items-center justify-center text-th-text-muted hover:bg-th-button-hover hover:text-th-text-primary transition-colors"
         >
@@ -125,7 +128,11 @@ export default function TitleBar() {
         </button>
         <button
           data-titlebar-button
-          onClick={toggleMaximize}
+          onClick={(e) => {
+            e.stopPropagation();
+            toggleMaximize();
+          }}
+          onMouseDown={(e) => e.stopPropagation()}
           aria-label={isMaximized ? "Restore" : "Maximize"}
           className="w-7 h-7 rounded-full flex items-center justify-center text-th-text-muted hover:bg-th-button-hover hover:text-th-text-primary transition-colors"
         >
@@ -133,7 +140,11 @@ export default function TitleBar() {
         </button>
         <button
           data-titlebar-button
-          onClick={close}
+          onClick={(e) => {
+            e.stopPropagation();
+            close();
+          }}
+          onMouseDown={(e) => e.stopPropagation()}
           aria-label="Close"
           className="w-7 h-7 rounded-full flex items-center justify-center text-th-text-muted hover:bg-red-500/80 hover:text-white transition-colors"
         >


### PR DESCRIPTION
### Summary

- **Restore maximized window state (`src-tauri/src/lib.rs`)**: `tauri_plugin_window_state` was initialized without `StateFlags::MAXIMIZED`, preventing the maximized state from being saved and restored across sessions. Added `StateFlags::MAXIMIZED` to `with_state_flags`.
- **TitleBar window control responsiveness (`src/components/TitleBar.tsx`)**: Removed `data-tauri-drag-region` from the root titlebar wrapper to prevent WebKitGTK / GTK on Linux (especially Wayland) from capturing clicks on window buttons as window move drags. Added `stopPropagation` on mouse down and click events for the minimize, maximize/restore, and close buttons.
- **Tests (`src/components/TitleBar.test.tsx`)**: Added unit tests covering window control interactions and drag-region isolation.

Closes #183