### PR TITLE
fix(ui): harmonize header navigation buttons and titlebar with active theme

### DIFF
--- a/src/components/Header.test.tsx
+++ b/src/components/Header.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, cleanup, fireEvent } from "@testing-library/react";
+
+vi.mock("./UserMenu", () => ({
+  default: () => <div data-testid="user-menu" />,
+}));
+vi.mock("./SearchBar", () => ({
+  default: () => <div data-testid="search-bar" />,
+}));
+
+import Header from "./Header";
+
+describe("Header", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders back and forward buttons with theme tokens", () => {
+    const { getByRole } = render(<Header />);
+    const backBtn = getByRole("button", { name: /go back/i });
+    const forwardBtn = getByRole("button", { name: /go forward/i });
+
+    expect(backBtn.className).toContain("bg-th-inset");
+    expect(backBtn.className).toContain("hover:bg-th-inset-hover");
+    expect(forwardBtn.className).toContain("bg-th-inset");
+    expect(forwardBtn.className).toContain("hover:bg-th-inset-hover");
+  });
+
+  it("calls window.history.back and forward on click", () => {
+    const backSpy = vi
+      .spyOn(window.history, "back")
+      .mockImplementation(() => {});
+    const forwardSpy = vi
+      .spyOn(window.history, "forward")
+      .mockImplementation(() => {});
+
+    const { getByRole } = render(<Header />);
+    const backBtn = getByRole("button", { name: /go back/i });
+    const forwardBtn = getByRole("button", { name: /go forward/i });
+
+    fireEvent.click(backBtn);
+    expect(backSpy).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(forwardBtn);
+    expect(forwardSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/Header.test.tsx
+++ b/src/components/Header.test.tsx
@@ -1,17 +1,17 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { render, cleanup, fireEvent } from "@testing-library/react";
 
 vi.mock("./UserMenu", () => ({
-  default: () => <div data-testid="user-menu" />,
+  default: () => <div />,
 }));
 vi.mock("./SearchBar", () => ({
-  default: () => <div data-testid="search-bar" />,
+  default: () => <div />,
 }));
 
 import Header from "./Header";
 
 describe("Header", () => {
-  beforeEach(() => {
+  afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
   });
@@ -21,10 +21,13 @@ describe("Header", () => {
     const backBtn = getByRole("button", { name: /go back/i });
     const forwardBtn = getByRole("button", { name: /go forward/i });
 
-    expect(backBtn.className).toContain("bg-th-inset");
-    expect(backBtn.className).toContain("hover:bg-th-inset-hover");
-    expect(forwardBtn.className).toContain("bg-th-inset");
-    expect(forwardBtn.className).toContain("hover:bg-th-inset-hover");
+    for (const btn of [backBtn, forwardBtn]) {
+      // classList matches whole tokens; a `className.includes` check would be
+      // satisfied by the `hover:` variant alone and never fail.
+      expect(btn.classList.contains("bg-th-inset")).toBe(true);
+      expect(btn.classList.contains("hover:bg-th-inset-hover")).toBe(true);
+      expect(btn.className).not.toContain("bg-black");
+    }
   });
 
   it("calls window.history.back and forward on click", () => {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -20,13 +20,15 @@ export default function Header() {
         <div className="flex items-center gap-2 shrink-0">
           <button
             onClick={() => window.history.back()}
-            className="w-8 h-8 rounded-full bg-black/40 flex items-center justify-center text-th-text-muted hover:text-th-text-primary transition-colors disabled:opacity-50"
+            aria-label="Go back"
+            className="w-8 h-8 rounded-full bg-th-inset hover:bg-th-inset-hover flex items-center justify-center text-th-text-muted hover:text-th-text-primary transition-colors disabled:opacity-50"
           >
             <ChevronLeft size={20} />
           </button>
           <button
             onClick={() => window.history.forward()}
-            className="w-8 h-8 rounded-full bg-black/40 flex items-center justify-center text-th-text-muted hover:text-th-text-primary transition-colors disabled:opacity-50"
+            aria-label="Go forward"
+            className="w-8 h-8 rounded-full bg-th-inset hover:bg-th-inset-hover flex items-center justify-center text-th-text-muted hover:text-th-text-primary transition-colors disabled:opacity-50"
           >
             <ChevronRight size={20} />
           </button>

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -104,7 +104,11 @@ export default function TitleBar() {
         >
           SONE
         </span>
-        <span className="w-1.5 h-1.5 rounded-full bg-th-accent shrink-0" />
+        <span
+          className={`w-1.5 h-1.5 rounded-full bg-th-accent shrink-0 pointer-events-none transition-opacity ${
+            isFocused ? "opacity-100" : "opacity-50"
+          }`}
+        />
       </div>
 
       {/* Middle zone (flex grows to fill — draggable) */}
@@ -120,7 +124,7 @@ export default function TitleBar() {
           data-titlebar-button
           onClick={minimize}
           aria-label="Minimize"
-          className="w-7 h-7 rounded-full flex items-center justify-center text-th-text-muted hover:bg-th-surface-hover hover:text-th-text-primary transition-colors"
+          className="w-7 h-7 rounded-full flex items-center justify-center text-th-text-muted hover:bg-th-button-hover hover:text-th-text-primary transition-colors"
         >
           <Minus size={14} />
         </button>
@@ -128,7 +132,7 @@ export default function TitleBar() {
           data-titlebar-button
           onClick={toggleMaximize}
           aria-label={isMaximized ? "Restore" : "Maximize"}
-          className="w-7 h-7 rounded-full flex items-center justify-center text-th-text-muted hover:bg-th-surface-hover hover:text-th-text-primary transition-colors"
+          className="w-7 h-7 rounded-full flex items-center justify-center text-th-text-muted hover:bg-th-button-hover hover:text-th-text-primary transition-colors"
         >
           {isMaximized ? <Copy size={12} /> : <Square size={12} />}
         </button>

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -79,10 +79,10 @@ export default function TitleBar() {
     <div
       data-tauri-drag-region
       onDoubleClick={handleDoubleClick}
-      className="flex items-center justify-between bg-th-overlay border-b border-th-border-subtle select-none shrink-0"
+      className="flex items-center justify-between bg-th-surface border-b border-th-border-subtle select-none shrink-0"
       style={{ height: TITLEBAR_HEIGHT }}
     >
-      {/* Left zone: app icon + wordmark (also draggable) */}
+      {/* Left zone: app icon + wordmark + accent indicator (also draggable) */}
       <div
         data-tauri-drag-region
         className="flex items-center gap-2 pl-3 pr-4 h-full"
@@ -98,12 +98,13 @@ export default function TitleBar() {
           }`}
         />
         <span
-          className={`text-[11px] font-semibold tracking-wider text-th-text-secondary transition-opacity ${
+          className={`text-[11px] font-semibold tracking-wider text-th-text-primary transition-opacity ${
             isFocused ? "opacity-100" : "opacity-50"
           }`}
         >
           SONE
         </span>
+        <span className="w-1.5 h-1.5 rounded-full bg-th-accent shrink-0" />
       </div>
 
       {/* Middle zone (flex grows to fill — draggable) */}
@@ -119,7 +120,7 @@ export default function TitleBar() {
           data-titlebar-button
           onClick={minimize}
           aria-label="Minimize"
-          className="w-7 h-7 rounded-full flex items-center justify-center text-th-text-muted hover:bg-th-button-hover hover:text-th-text-primary transition-colors"
+          className="w-7 h-7 rounded-full flex items-center justify-center text-th-text-muted hover:bg-th-surface-hover hover:text-th-text-primary transition-colors"
         >
           <Minus size={14} />
         </button>
@@ -127,7 +128,7 @@ export default function TitleBar() {
           data-titlebar-button
           onClick={toggleMaximize}
           aria-label={isMaximized ? "Restore" : "Maximize"}
-          className="w-7 h-7 rounded-full flex items-center justify-center text-th-text-muted hover:bg-th-button-hover hover:text-th-text-primary transition-colors"
+          className="w-7 h-7 rounded-full flex items-center justify-center text-th-text-muted hover:bg-th-surface-hover hover:text-th-text-primary transition-colors"
         >
           {isMaximized ? <Copy size={12} /> : <Square size={12} />}
         </button>


### PR DESCRIPTION
### Summary

- **Header navigation buttons (`src/components/Header.tsx`)**: The back and forward buttons previously used hardcoded `bg-black/40` without themed hover states, appearing out-of-tone on light and colored themes. Updated to use theme tokens `bg-th-inset hover:bg-th-inset-hover text-th-text-muted hover:text-th-text-primary`.
- **Custom TitleBar (`src/components/TitleBar.tsx`)**: Updated the titlebar container from `bg-th-overlay` to `bg-th-surface border-b border-th-border-subtle`, styled the wordmark with `text-th-text-primary`, added a theme accent indicator (`bg-th-accent`), and updated window button hover states to `hover:bg-th-surface-hover` so the titlebar matches the active theme.
- **Tests (`src/components/Header.test.tsx`)**: Added unit tests for Header navigation buttons.