### PR TITLE
Fix now-playing drawer covering the title bar, cropping art, and hijacking video fullscreen

### DIFF
--- a/src/components/NowPlayingDrawer.fullscreen.test.tsx
+++ b/src/components/NowPlayingDrawer.fullscreen.test.tsx
@@ -1,0 +1,101 @@
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { Provider, createStore } from "jotai";
+
+// The drawer reaches the Tauri bridge for image bytes and favourites — stub it
+// so the render never hits a backend.
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(() => Promise.resolve(undefined)),
+}));
+
+// The drawer pulls in TitleBar and the video actions, both of which reach for
+// the Tauri window. Only setFullscreen is asserted on.
+const { windowMock } = vi.hoisted(() => ({
+  windowMock: {
+    setFullscreen: vi.fn(() => Promise.resolve()),
+    isMaximized: vi.fn(() => Promise.resolve(false)),
+    isFocused: vi.fn(() => Promise.resolve(true)),
+    onResized: vi.fn(() => Promise.resolve(() => {})),
+    onFocusChanged: vi.fn(() => Promise.resolve(() => {})),
+  },
+}));
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => windowMock,
+}));
+
+import NowPlayingDrawer from "./NowPlayingDrawer";
+import { ToastProvider } from "../contexts/ToastContext";
+import { currentTrackAtom } from "../atoms/playback";
+import { drawerOpenAtom, maximizedPlayerAtom } from "../atoms/ui";
+import {
+  currentVideoAtom,
+  videoExpandedAtom,
+  videoFullscreenAtom,
+} from "../atoms/video";
+import type { Track, TidalVideo } from "../types";
+
+const track = {
+  id: 1,
+  title: "Song",
+  duration: 100,
+  artist: { id: 2, name: "Artist" },
+  artists: [{ id: 2, name: "Artist" }],
+  album: { id: 3, title: "Album", cover: "cover" },
+} as unknown as Track;
+
+const video = {
+  id: 42,
+  title: "Clip",
+  duration: 200,
+} as unknown as TidalVideo;
+
+function renderDrawer({ playingVideo = false } = {}) {
+  const store = createStore();
+  store.set(currentTrackAtom, track);
+  store.set(drawerOpenAtom, true);
+  if (playingVideo) {
+    store.set(currentVideoAtom, video);
+    // The overlay is minimized to the player bar — the video keeps playing.
+    store.set(videoExpandedAtom, false);
+  }
+  render(
+    <Provider store={store}>
+      <ToastProvider>
+        <NowPlayingDrawer />
+      </ToastProvider>
+    </Provider>,
+  );
+  return store;
+}
+
+describe("Drawer fullscreen button", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("plays the video fullscreen while a video is playing", () => {
+    const store = renderDrawer({ playingVideo: true });
+    fireEvent.click(screen.getByTitle(/^Fullscreen/));
+    expect(store.get(videoExpandedAtom)).toBe(true);
+    expect(store.get(videoFullscreenAtom)).toBe(true);
+    expect(windowMock.setFullscreen).toHaveBeenCalledWith(true);
+    expect(store.get(maximizedPlayerAtom)).toBe(false);
+  });
+
+  it("opens the audio fullscreen player when no video is playing", () => {
+    const store = renderDrawer();
+    fireEvent.click(screen.getByTitle(/^Fullscreen/));
+    expect(store.get(maximizedPlayerAtom)).toBe(true);
+    expect(store.get(videoExpandedAtom)).toBe(false);
+    expect(windowMock.setFullscreen).not.toHaveBeenCalled();
+  });
+
+  it("labels the button for whichever player it opens", () => {
+    renderDrawer({ playingVideo: true });
+    expect(screen.getByTitle("Fullscreen video")).not.toBeNull();
+    cleanup();
+    renderDrawer();
+    expect(screen.getByTitle("Fullscreen player")).not.toBeNull();
+  });
+});

--- a/src/components/NowPlayingDrawer.titlebar.test.tsx
+++ b/src/components/NowPlayingDrawer.titlebar.test.tsx
@@ -1,0 +1,63 @@
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { Provider, createStore } from "jotai";
+
+// The drawer reaches the Tauri bridge for image bytes and favourites — stub it
+// so the render never hits a backend.
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(() => Promise.resolve(undefined)),
+}));
+
+import NowPlayingDrawer from "./NowPlayingDrawer";
+import { TITLEBAR_HEIGHT } from "./TitleBar";
+import { ToastProvider } from "../contexts/ToastContext";
+import { currentTrackAtom } from "../atoms/playback";
+import { decorationsAtom, drawerOpenAtom, hideTitleBarAtom } from "../atoms/ui";
+import type { Track } from "../types";
+
+const track = {
+  id: 1,
+  title: "Song",
+  duration: 100,
+  artist: { id: 2, name: "Artist" },
+  artists: [{ id: 2, name: "Artist" }],
+  album: { id: 3, title: "Album", cover: "cover" },
+} as unknown as Track;
+
+function renderDrawer(
+  chrome: { nativeChrome?: boolean; hideTitleBar?: boolean } = {},
+) {
+  const store = createStore();
+  store.set(currentTrackAtom, track);
+  store.set(drawerOpenAtom, true);
+  store.set(decorationsAtom, chrome.nativeChrome ?? false);
+  store.set(hideTitleBarAtom, chrome.hideTitleBar ?? false);
+  const { container } = render(
+    <Provider store={store}>
+      <ToastProvider>
+        <NowPlayingDrawer />
+      </ToastProvider>
+    </Provider>,
+  );
+  const root = container.querySelector<HTMLElement>(".z-40");
+  expect(root).not.toBeNull();
+  return root!;
+}
+
+describe("Now-playing drawer top edge", () => {
+  afterEach(cleanup);
+
+  it("stops below the custom title bar so the window stays draggable", () => {
+    expect(getComputedStyle(renderDrawer()).top).toBe(`${TITLEBAR_HEIGHT}px`);
+  });
+
+  it("reaches the window top when the OS draws the chrome", () => {
+    const root = renderDrawer({ nativeChrome: true });
+    expect(getComputedStyle(root).top).toBe("0px");
+  });
+
+  it("reaches the window top when the title bar is hidden entirely", () => {
+    const root = renderDrawer({ hideTitleBar: true });
+    expect(getComputedStyle(root).top).toBe("0px");
+  });
+});

--- a/src/components/NowPlayingDrawer.tsx
+++ b/src/components/NowPlayingDrawer.tsx
@@ -35,7 +35,12 @@ import {
   playbackSourceAtom,
   contextSourceAtom,
 } from "../atoms/playback";
-import { maximizedPlayerAtom, videoCoversAtom } from "../atoms/ui";
+import {
+  decorationsAtom,
+  hideTitleBarAtom,
+  maximizedPlayerAtom,
+  videoCoversAtom,
+} from "../atoms/ui";
 import { usePlaybackActions } from "../hooks/usePlaybackActions";
 import { useDrawer } from "../hooks/useDrawer";
 import { useFavorites } from "../hooks/useFavorites";
@@ -60,6 +65,7 @@ import {
   type Credit,
 } from "../types";
 import TidalImage from "./TidalImage";
+import { TITLEBAR_HEIGHT } from "./TitleBar";
 import TidalVideoCover from "./TidalVideoCover";
 import { TiltCover } from "./TiltCover";
 import TrackContextMenu from "./TrackContextMenu";
@@ -1573,6 +1579,11 @@ export default function NowPlayingDrawer() {
     DISMISS_PRIORITY.drawer,
   );
   const setMaximized = useSetAtom(maximizedPlayerAtom);
+  const nativeChrome = useAtomValue(decorationsAtom);
+  const hideTitleBar = useAtomValue(hideTitleBarAtom);
+  // The custom title bar is in normal flow, so a top:0 overlay paints over its
+  // drag region and window buttons — leave it uncovered when it's showing.
+  const titleBarInset = !nativeChrome && !hideTitleBar ? TITLEBAR_HEIGHT : 0;
   const activeTab = (drawerTab || "queue") as TabId;
   const setActiveTab = (tab: TabId) => setDrawerTab(tab);
 
@@ -1593,9 +1604,10 @@ export default function NowPlayingDrawer() {
 
   return (
     <div
-      className={`fixed inset-0 bottom-[90px] z-40 flex flex-col transition-[visibility] ${
+      className={`fixed inset-x-0 bottom-[90px] z-40 flex flex-col transition-[visibility] ${
         drawerOpen ? "visible" : "invisible delay-200"
       }`}
+      style={{ top: titleBarInset }}
     >
       {/* Backdrop */}
       <div

--- a/src/components/NowPlayingDrawer.tsx
+++ b/src/components/NowPlayingDrawer.tsx
@@ -57,6 +57,8 @@ import {
 } from "../api/tidal";
 import BioText from "./BioText";
 import { isTrackUnavailable } from "../lib/trackAvailability";
+import { COVER_TEXT_GAP, MAX_COVER_SIZE } from "../lib/coverFit";
+import { useFittedCoverSize } from "../hooks/useFittedCoverSize";
 import {
   getTidalImageUrl,
   getTrackDisplayTitle,
@@ -1584,6 +1586,11 @@ export default function NowPlayingDrawer() {
   // The custom title bar is in normal flow, so a top:0 overlay paints over its
   // drag region and window buttons — leave it uncovered when it's showing.
   const titleBarInset = !nativeChrome && !hideTitleBar ? TITLEBAR_HEIGHT : 0;
+  const {
+    columnRef: coverColumnRef,
+    textRef: coverTextRef,
+    size: coverSize,
+  } = useFittedCoverSize();
   const activeTab = (drawerTab || "queue") as TabId;
   const setActiveTab = (tab: TabId) => setDrawerTab(tab);
 
@@ -1638,27 +1645,39 @@ export default function NowPlayingDrawer() {
           }}
         />
 
-        {/* Left: Album Art — 45% */}
-        <div className="relative z-[1] w-[45%] flex flex-col items-center justify-center p-10 gap-6">
-          {animatedCover ? (
-            <TidalVideoCover
-              cover={currentTrack.album?.cover}
-              videoCover={currentTrack.album?.videoCover}
-              size={1280}
-              imageSize={640}
-              alt={currentTrack.album?.title || currentTrack.title}
-              className="w-full max-w-[640px] aspect-square rounded-lg overflow-hidden"
-            />
-          ) : (
-            <TiltCover className="w-full max-w-[640px] aspect-square rounded-lg">
-              <TidalImage
-                src={getTidalImageUrl(trackCoverId(currentTrack), 640)}
+        {/* Left: Album Art — 45% (cover sized to fit the column in both axes) */}
+        <div
+          ref={coverColumnRef}
+          className="relative z-[1] w-[45%] flex flex-col items-center justify-center p-10"
+          style={{ gap: COVER_TEXT_GAP }}
+        >
+          <div
+            className="w-full aspect-square shrink-0"
+            style={{ maxWidth: MAX_COVER_SIZE, width: coverSize ?? undefined }}
+          >
+            {animatedCover ? (
+              <TidalVideoCover
+                cover={currentTrack.album?.cover}
+                videoCover={currentTrack.album?.videoCover}
+                size={1280}
+                imageSize={640}
                 alt={currentTrack.album?.title || currentTrack.title}
-                className="w-full h-full"
+                className="w-full h-full rounded-lg overflow-hidden"
               />
-            </TiltCover>
-          )}
-          <div className="text-center w-full max-w-[520px]">
+            ) : (
+              <TiltCover className="w-full h-full rounded-lg">
+                <TidalImage
+                  src={getTidalImageUrl(trackCoverId(currentTrack), 640)}
+                  alt={currentTrack.album?.title || currentTrack.title}
+                  className="w-full h-full"
+                />
+              </TiltCover>
+            )}
+          </div>
+          <div
+            ref={coverTextRef}
+            className="shrink-0 text-center w-full max-w-[520px]"
+          >
             <h2 className="text-[22px] font-bold text-th-text-primary truncate">
               {getTrackDisplayTitle(currentTrack)}
             </h2>

--- a/src/components/NowPlayingDrawer.tsx
+++ b/src/components/NowPlayingDrawer.tsx
@@ -41,7 +41,9 @@ import {
   maximizedPlayerAtom,
   videoCoversAtom,
 } from "../atoms/ui";
+import { currentVideoAtom } from "../atoms/video";
 import { usePlaybackActions } from "../hooks/usePlaybackActions";
+import { useVideoPlayback } from "../hooks/useVideoPlayback";
 import { useDrawer } from "../hooks/useDrawer";
 import { useFavorites } from "../hooks/useFavorites";
 import { useNavigation } from "../hooks/useNavigation";
@@ -1586,6 +1588,8 @@ export default function NowPlayingDrawer() {
   // The custom title bar is in normal flow, so a top:0 overlay paints over its
   // drag region and window buttons — leave it uncovered when it's showing.
   const titleBarInset = !nativeChrome && !hideTitleBar ? TITLEBAR_HEIGHT : 0;
+  const currentVideo = useAtomValue(currentVideoAtom);
+  const { fullscreenVideo } = useVideoPlayback();
   const {
     columnRef: coverColumnRef,
     textRef: coverTextRef,
@@ -1709,9 +1713,11 @@ export default function NowPlayingDrawer() {
             </div>
             <div className="flex items-center gap-1 shrink-0 ml-2">
               <button
-                onClick={() => setMaximized(true)}
+                onClick={() =>
+                  currentVideo ? fullscreenVideo() : setMaximized(true)
+                }
                 className="w-8 h-8 rounded-full flex items-center justify-center text-th-text-muted hover:text-th-text-primary hover:bg-th-hl-med transition-colors duration-150"
-                title="Fullscreen player"
+                title={currentVideo ? "Fullscreen video" : "Fullscreen player"}
               >
                 <Maximize2 size={18} />
               </button>

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useCallback } from "react";
 import { Minus, X, Square, Copy } from "lucide-react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 
-const TITLEBAR_HEIGHT = 32;
+export const TITLEBAR_HEIGHT = 32;
 
 function useWindowControls() {
   const [isMaximized, setIsMaximized] = useState(false);

--- a/src/hooks/useFittedCoverSize.test.tsx
+++ b/src/hooks/useFittedCoverSize.test.tsx
@@ -1,0 +1,78 @@
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { act, cleanup, render } from "@testing-library/react";
+import { useFittedCoverSize } from "./useFittedCoverSize";
+
+type Box = { width: number; height: number };
+
+/** jsdom ships no ResizeObserver — this one lets a test drive the callback. */
+class FakeResizeObserver {
+  static latest: FakeResizeObserver | null = null;
+  observed: Element[] = [];
+  constructor(private cb: (entries: { contentRect: Box }[]) => void) {
+    FakeResizeObserver.latest = this;
+  }
+  observe(el: Element) {
+    this.observed.push(el);
+  }
+  disconnect() {}
+  emit(box: Box) {
+    act(() => this.cb([{ contentRect: box }]));
+  }
+}
+
+const TEXT_HEIGHT = 50;
+
+function Harness() {
+  const { columnRef, textRef, size } = useFittedCoverSize();
+  return (
+    <div ref={columnRef}>
+      <div data-testid="cover" style={size != null ? { width: size } : {}} />
+      <div
+        ref={(el) => {
+          if (el)
+            Object.defineProperty(el, "offsetHeight", {
+              configurable: true,
+              get: () => TEXT_HEIGHT,
+            });
+          textRef.current = el;
+        }}
+      />
+    </div>
+  );
+}
+
+function renderHarness() {
+  vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+  const { getByTestId } = render(<Harness />);
+  return {
+    cover: getByTestId("cover") as HTMLElement,
+    observer: FakeResizeObserver.latest!,
+  };
+}
+
+describe("useFittedCoverSize", () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    FakeResizeObserver.latest = null;
+  });
+
+  it("sizes the cover from the column's content box", () => {
+    const { cover, observer } = renderHarness();
+    observer.emit({ width: 900, height: 300 });
+    // 300 tall - 24 gap - 50 text = 226, narrower than the 900 available.
+    expect(cover.style.width).toBe("226px");
+  });
+
+  it("observes the column element", () => {
+    const { observer } = renderHarness();
+    expect(observer.observed).toHaveLength(1);
+  });
+
+  it("keeps the last good size when the drawer is hidden and reports zero", () => {
+    const { cover, observer } = renderHarness();
+    observer.emit({ width: 900, height: 300 });
+    observer.emit({ width: 0, height: 0 });
+    expect(cover.style.width).toBe("226px");
+  });
+});

--- a/src/hooks/useFittedCoverSize.ts
+++ b/src/hooks/useFittedCoverSize.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef, useState, type RefObject } from "react";
+import { fitCoverSize } from "../lib/coverFit";
+
+/**
+ * Sizes the drawer cover to fit its column in both axes: the observer reports
+ * the column's content box, the title block measures itself, and the cover
+ * takes the largest square left over.
+ */
+export function useFittedCoverSize(): {
+  columnRef: RefObject<HTMLDivElement | null>;
+  textRef: RefObject<HTMLDivElement | null>;
+  size: number | null;
+} {
+  const columnRef = useRef<HTMLDivElement | null>(null);
+  const textRef = useRef<HTMLDivElement | null>(null);
+  const [size, setSize] = useState<number | null>(null);
+
+  useEffect(() => {
+    const column = columnRef.current;
+    if (!column || typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver((entries) => {
+      const box = entries[entries.length - 1]?.contentRect;
+      // Layout hides the drawer behind the video overlay with display:none —
+      // hold the last good size rather than collapsing the cover to nothing.
+      if (!box || box.width === 0 || box.height === 0) return;
+      setSize(
+        fitCoverSize({
+          width: box.width,
+          height: box.height,
+          textHeight: textRef.current?.offsetHeight ?? 0,
+        }),
+      );
+    });
+    observer.observe(column);
+    return () => observer.disconnect();
+  }, []);
+
+  return { columnRef, textRef, size };
+}

--- a/src/hooks/useVideoPlayback.ts
+++ b/src/hooks/useVideoPlayback.ts
@@ -76,6 +76,15 @@ export function useVideoPlayback() {
     store.set(videoExpandedAtom, true);
   }, [store]);
 
+  /** Re-open the overlay and take the window fullscreen for the video. */
+  const fullscreenVideo = useCallback(() => {
+    store.set(videoExpandedAtom, true);
+    store.set(videoFullscreenAtom, true);
+    getCurrentWindow()
+      .setFullscreen(true)
+      .catch(() => {});
+  }, [store]);
+
   const closeVideo = useCallback(() => {
     store.set(videoPlayingAtom, false);
     store.set(videoStreamAtom, null);
@@ -94,6 +103,7 @@ export function useVideoPlayback() {
     setVideoQuality,
     minimizeVideo,
     expandVideo,
+    fullscreenVideo,
     closeVideo,
   };
 }

--- a/src/lib/coverFit.test.ts
+++ b/src/lib/coverFit.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { fitCoverSize, MAX_COVER_SIZE } from "./coverFit";
+
+describe("fitCoverSize", () => {
+  it("fills the width when the column is tall and narrow", () => {
+    expect(fitCoverSize({ width: 300, height: 900, textHeight: 50 })).toBe(300);
+  });
+
+  it("leaves room for the gap and the title block when the column is short", () => {
+    expect(
+      fitCoverSize({ width: 900, height: 300, textHeight: 50, gap: 24 }),
+    ).toBe(226);
+  });
+
+  it("stops growing at the maximum cover size", () => {
+    expect(fitCoverSize({ width: 1200, height: 1200, textHeight: 50 })).toBe(
+      MAX_COVER_SIZE,
+    );
+  });
+
+  it("floors fractional space to whole pixels", () => {
+    expect(fitCoverSize({ width: 300.7, height: 900, textHeight: 50 })).toBe(
+      300,
+    );
+  });
+
+  it("never returns a negative size when the column is tiny", () => {
+    expect(fitCoverSize({ width: 100, height: 40, textHeight: 50 })).toBe(0);
+  });
+});

--- a/src/lib/coverFit.ts
+++ b/src/lib/coverFit.ts
@@ -1,0 +1,29 @@
+/** Largest cover the drawer ever draws, matching the 640px art it requests. */
+export const MAX_COVER_SIZE = 640;
+/** Vertical gap between the cover and the title block, in px. */
+export const COVER_TEXT_GAP = 24;
+
+interface CoverFitInput {
+  /** Content-box width of the art column (padding already excluded). */
+  width: number;
+  /** Content-box height of the art column. */
+  height: number;
+  /** Measured height of the title/artist block below the cover. */
+  textHeight: number;
+  gap?: number;
+  max?: number;
+}
+
+/** Side length of the largest square cover that fits the column in both axes. */
+export function fitCoverSize({
+  width,
+  height,
+  textHeight,
+  gap = COVER_TEXT_GAP,
+  max = MAX_COVER_SIZE,
+}: CoverFitInput): number {
+  return Math.max(
+    0,
+    Math.floor(Math.min(width, height - gap - textHeight, max)),
+  );
+}


### PR DESCRIPTION
Fixes #212.

### Bugs

- With the custom title bar enabled, opening the now-playing details panel (queue, suggested, lyrics, credits) covered the title bar, leaving no way to drag, minimize or close the window until the panel was closed.
- The album art in the details panel scaled to the column's width only, so a short window cropped the top and bottom of the cover — measured at 136–306px lost between 600px and 430px window heights.
- With a video playing, the panel's fullscreen button opened the audio fullscreen player instead of playing the video fullscreen. The two players are separate UI.