### PR TITLE
ci: run the test suites on every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,105 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+# Read-only by default; no job here needs write access or secrets.
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  frontend:
+    name: Frontend tests
+    # Pinned rather than ubuntu-latest so a runner image migration cannot
+    # silently change the toolchain under us.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm test
+
+  rust:
+    name: Rust tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libdbus-1-dev \
+            libgstreamer1.0-dev \
+            libgstreamer-plugins-base1.0-dev \
+            libsecret-1-dev \
+            libasound2-dev
+
+      - name: Set up Rust
+        # This action publishes no version tags; `stable` is a moving branch,
+        # so the pin is date-stamped to keep it auditable after the fact.
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable branch @ 2026-09-03
+        with:
+          toolchain: stable
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          workspaces: src-tauri
+          # Pull requests restore from master but never write, so PR traffic
+          # cannot evict master's entries from the shared 10 GB repo budget.
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # generate_context! embeds ../dist at compile time, so the crate does not
+      # build at all without a frontend bundle present.
+      - name: Build frontend
+        run: pnpm build
+
+      - name: Run tests
+        run: cargo test --manifest-path src-tauri/Cargo.toml --locked
+        env:
+          RUST_BACKTRACE: "1"


### PR DESCRIPTION
### Problems

- Nothing runs the test suites automatically. 374 frontend tests and 154 Rust tests only ever run when someone remembers to run them locally, so a regression can reach `master` without anyone noticing.
- A pull request gives no signal about whether it breaks anything, so review has to take "tests pass" on trust.

Adds two jobs — frontend (`pnpm test`) and Rust (`cargo test`) — running on every pull request and on pushes to `master`.

Note: this cannot actually block a merge until `ci / Frontend tests` and `ci / Rust tests` are added as required status checks in the `master` ruleset.
