### PR TITLE
fix(audio): release ALSA device when exclusive mode is disabled

### DIFF
--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -2402,8 +2402,67 @@ impl AudioPlayer {
                         if let Some(d) = dev {
                             device = Some(d);
                         }
+                        // Disabling exclusive mode must actively release the ALSA
+                        // hardware device. Previously we only flipped the mode flag
+                        // and left any live DirectAlsa pipeline + writer thread
+                        // running, so the exclusive `hw:` PCM stayed open — leaving
+                        // the device "busy"/unavailable to PipeWire (and thus the
+                        // system UI) until the next PlayUrl or app exit. Tear the
+                        // DirectAlsa backend down here so the device frees the moment
+                        // the user leaves exclusive mode.
                         if !enabled {
                             bit_perfect = false;
+                            // Single match on the taken backend: only DirectAlsa
+                            // holds the exclusive `hw:` device and needs teardown.
+                            // Any other backend is put back untouched.
+                            match backend.take() {
+                                Some(PlaybackBackend::DirectAlsa { pipeline, .. }) => {
+                                    tearing_down.store(true, Ordering::SeqCst);
+                                    // Unblock writer if paused and invalidate its
+                                    // generation so it discards stale Data and the
+                                    // pipeline can reach Null without blocking.
+                                    paused.store(false, Ordering::Release);
+                                    track_generation += 1;
+                                    writer_gen.store(track_generation, Ordering::Release);
+                                    if let Some(ref tx) = writer_tx {
+                                        let _ = tx.send_timeout(
+                                            WriterCommand::Flush,
+                                            std::time::Duration::from_millis(200),
+                                        );
+                                    }
+                                    if let Some(bus) = pipeline.bus() {
+                                        bus.set_flushing(true);
+                                    }
+                                    pipeline.set_state(gst::State::Null).ok();
+                                    let _ = pipeline.state(gst::ClockTime::from_mseconds(500));
+                                    drop(pipeline);
+
+                                    // Shut down the ALSA writer thread — it owns the
+                                    // exclusive `hw:` handle, so joining it closes the
+                                    // device fd. Writer state is cleared so a later
+                                    // play re-spawns and re-negotiates cleanly.
+                                    if let Some(tx) = writer_tx.take() {
+                                        tx.try_send(WriterCommand::Shutdown).ok();
+                                    }
+                                    if let Some(h) = writer_thread.take() {
+                                        h.join().ok();
+                                    }
+                                    writer_fmt = None;
+                                    writer_supported_fmts = None;
+                                    writer_supported_rates = None;
+                                    writer_device = None;
+                                    writer_bit_perfect = None;
+                                    has_uri.store(false, Ordering::SeqCst);
+                                    eos.store(false, Ordering::SeqCst);
+                                    tearing_down.store(false, Ordering::SeqCst);
+                                    log::info!(
+                                        "[audio] exclusive disabled: DirectAlsa torn down, ALSA device released"
+                                    );
+                                }
+                                // Not DirectAlsa (Normal, or nothing playing): keep
+                                // the active backend as-is.
+                                other => backend = other,
+                            }
                         }
                         // Mirror the device into the shared cell so the
                         // pipeline probe can read it without messaging.


### PR DESCRIPTION
## Summary

  Disabling exclusive (bit-perfect) mode now actively releases the ALSA
  hardware device, so the DAC becomes immediately available to PipeWire/
  PulseAudio and the desktop's audio output selection again — without
  having to start another track or quit SONE.

  ## Bug scenario

  On a PipeWire + WirePlumber system (reproduced on CachyOS with niri +
  Noctalia, USB DAC), the flow was:

  1. Enable exclusive / bit-perfect mode in SONE and play a track. SONE
     opens the DAC directly via ALSA (`hw:`) for bit-perfect output and
     holds that PCM device open.
  2. Turn exclusive mode **off** in the UI (intending to use the DAC in
     another app, e.g. a browser).
  3. The DAC disappears from the system's output-device list and cannot
     be selected. WirePlumber logs `Failed to create ALSA node ... :
     Object activation aborted` because the device is still busy.

  Root cause: in the audio worker's `AudioCommand::SetExclusiveMode`
  handler, disabling exclusive mode only flipped the `exclusive` /
  `bit_perfect` flags and cleared the shared device cell. The currently
  active `PlaybackBackend::DirectAlsa` pipeline and its ALSA **writer
  thread** were left running. Since the writer thread owns the exclusive
  `hw:` device handle, the raw PCM file descriptor stayed open, so the
  device remained "busy" to PipeWire until the next `PlayUrl` or until
  SONE exited. This was confirmed at the OS level: `fuser /dev/snd/pcmC*D0p`
  showed the SONE process holding the device open after the toggle, and
  the sink only reappeared once SONE released the fd.

  ## Fix

  In the `SetExclusiveMode` handler, when `enabled == false`, tear the
  DirectAlsa backend down instead of leaving it running:

  - `match backend.take()`; for `DirectAlsa`, reuse the same teardown the
    `PlayUrl` path already uses: set `tearing_down`, unblock the writer,
    bump the writer generation, flush, set the GStreamer pipeline to
    `gst::State::Null`, drain, and drop it.
  - Shut down and `join()` the ALSA writer thread — joining it closes the
    exclusive device fd, freeing the DAC.
  - Clear writer state (`writer_fmt`, `writer_device`, etc.) and reset
    `has_uri` / `eos` so a later play re-spawns and re-negotiates cleanly.
  - Non-DirectAlsa backends (Normal, or nothing playing) are put back
    untouched.

  ## Testing

  - `cargo check` passes; the edited region is clippy- and rustfmt-clean.
  - Built with `pnpm tauri build` and verified at runtime on a real USB
    DAC: enabling exclusive mode + playing shows the process holding
    `/dev/snd/pcmC5D0p` (device "held", sink missing). Disabling exclusive
    mode logs `exclusive disabled: DirectAlsa torn down, ALSA device
    released`, the device immediately becomes free (`fuser` shows no
    holder), and the sink reappears in `pactl`/WirePlumber for selection
    in other apps.

  ## Note

  This fix was diagnosed and implemented with AI assistance (Kiro / Amazon Q),
  reviewed and tested by the author.